### PR TITLE
fix(pool): allow for connectionParams string

### DIFF
--- a/pool.ts
+++ b/pool.ts
@@ -9,7 +9,7 @@ import { DeferredStack } from "./deferred.ts";
 import { Query, QueryConfig, QueryResult } from "./query.ts";
 
 export class Pool {
-  private _connectionParams: ConnectionParams | string;
+  private _connectionParams: ConnectionParams;
   private _connections!: Array<Connection>;
   private _availableConnections!: DeferredStack<Connection>;
   private _maxSize: number;
@@ -17,7 +17,7 @@ export class Pool {
   private _lazy: boolean;
 
   constructor(
-    connectionParams: ConnectionOptions,
+    connectionParams: ConnectionOptions | string,
     maxSize: number,
     lazy?: boolean,
   ) {

--- a/pool.ts
+++ b/pool.ts
@@ -9,7 +9,7 @@ import { DeferredStack } from "./deferred.ts";
 import { Query, QueryConfig, QueryResult } from "./query.ts";
 
 export class Pool {
-  private _connectionParams: ConnectionParams;
+  private _connectionParams: ConnectionParams | string;
   private _connections!: Array<Connection>;
   private _availableConnections!: DeferredStack<Connection>;
   private _maxSize: number;

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -21,3 +21,10 @@ test("badAuthData", async function () {
   }
   assert(thrown);
 });
+
+test("string client connection", async function () {
+  const {user, password, database, hostname, port} = TEST_CONNECTION_PARAMS
+  const client = new Client(`pgsql://${user}:${password}@${hostname}:${port}/${database}`);
+  const result = await client.query("SELECT * FROM ids;");
+  assert(result);
+})

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -25,7 +25,7 @@ test("badAuthData", async function () {
 test("string client connection", async function () {
   const { user, password, database, hostname, port } = TEST_CONNECTION_PARAMS;
   const client = new Client(
-    `pgsql://${user}:${password}@${hostname}:${port}/${database}`,
+    `postgres://${user}:${password}@${hostname}:${port}/${database}`,
   );
   const result = await client.query("SELECT * FROM ids;");
   assert(result);

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -28,5 +28,6 @@ test("string client connection", async function () {
     `postgres://${user}:${password}@${hostname}:${port}/${database}`,
   );
   const result = await client.query("SELECT * FROM ids;");
+  await client.end();
   assert(result);
 });

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -27,7 +27,7 @@ test("string client connection", async function () {
   const client = new Client(
     `postgres://${user}:${password}@${hostname}:${port}/${database}`,
   );
-  await cleint.connect();
+  await client.connect();
   const result = await client.query("SELECT true;");
   await client.end();
   assert(result);

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -23,8 +23,10 @@ test("badAuthData", async function () {
 });
 
 test("string client connection", async function () {
-  const {user, password, database, hostname, port} = TEST_CONNECTION_PARAMS
-  const client = new Client(`pgsql://${user}:${password}@${hostname}:${port}/${database}`);
+  const { user, password, database, hostname, port } = TEST_CONNECTION_PARAMS;
+  const client = new Client(
+    `pgsql://${user}:${password}@${hostname}:${port}/${database}`,
+  );
   const result = await client.query("SELECT * FROM ids;");
   assert(result);
-})
+});

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -27,7 +27,8 @@ test("string client connection", async function () {
   const client = new Client(
     `postgres://${user}:${password}@${hostname}:${port}/${database}`,
   );
-  const result = await client.query("SELECT * FROM ids;");
+  await cleint.connect();
+  const result = await client.query("SELECT true;");
   await client.end();
   assert(result);
 });

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -13,7 +13,8 @@ Deno.test("string pool connection", async function () {
     `postgres://${user}:${password}@${hostname}:${port}/${database}`,
     10,
   );
-  const result = await pool.query("SELECT * FROM ids;");
+  await pool.connect();
+  const result = await pool.query("SELECT true;");
   await pool.end();
   assert(result);
 });

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -8,11 +8,14 @@ import { delay } from "../utils.ts";
 import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
 
 Deno.test("string pool connection", async function () {
-  const {user, password, database, hostname, port} = TEST_CONNECTION_PARAMS
-  const pool = new Pool(`pgsql://${user}:${password}@${hostname}:${port}/${database}`, 10);
+  const { user, password, database, hostname, port } = TEST_CONNECTION_PARAMS;
+  const pool = new Pool(
+    `pgsql://${user}:${password}@${hostname}:${port}/${database}`,
+    10,
+  );
   const result = await pool.query("SELECT * FROM ids;");
   assert(result);
-})
+});
 
 async function testPool(
   t: (pool: Pool) => void | Promise<void>,

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -14,6 +14,7 @@ Deno.test("string pool connection", async function () {
     10,
   );
   const result = await pool.query("SELECT * FROM ids;");
+  await Pool.end();
   assert(result);
 });
 

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -14,7 +14,7 @@ Deno.test("string pool connection", async function () {
     10,
   );
   const result = await pool.query("SELECT * FROM ids;");
-  await Pool.end();
+  await pool.end();
   assert(result);
 });
 

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -1,10 +1,18 @@
 import {
+  assert,
   assertEquals,
   assertThrowsAsync,
 } from "../test_deps.ts";
 import { Pool } from "../pool.ts";
 import { delay } from "../utils.ts";
 import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
+
+Deno.test("string pool connection", async function () {
+  const {user, password, database, hostname, port} = TEST_CONNECTION_PARAMS
+  const pool = new Pool(`pgsql://${user}:${password}@${hostname}:${port}/${database}`, 10);
+  const result = await pool.query("SELECT * FROM ids;");
+  assert(result);
+})
 
 async function testPool(
   t: (pool: Pool) => void | Promise<void>,
@@ -27,6 +35,11 @@ async function testPool(
   const name = t.name;
   Deno.test({ fn, name });
 }
+
+testPool(async function simpleQuery(POOL) {
+  const result = await POOL.query("SELECT * FROM ids;");
+  assertEquals(result.rows.length, 2);
+});
 
 testPool(async function simpleQuery(POOL) {
   const result = await POOL.query("SELECT * FROM ids;");

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -10,7 +10,7 @@ import { TEST_CONNECTION_PARAMS, DEFAULT_SETUP } from "./constants.ts";
 Deno.test("string pool connection", async function () {
   const { user, password, database, hostname, port } = TEST_CONNECTION_PARAMS;
   const pool = new Pool(
-    `pgsql://${user}:${password}@${hostname}:${port}/${database}`,
+    `postgres://${user}:${password}@${hostname}:${port}/${database}`,
     10,
   );
   const result = await pool.query("SELECT * FROM ids;");


### PR DESCRIPTION
`Pool` uses `createParams` to generate options, which allows for `string | ConnectionOptions`. This aligns `Pool` to that type.