### PR TITLE
Display notice message

### DIFF
--- a/connection.ts
+++ b/connection.ts
@@ -342,7 +342,11 @@ export class Connection {
         case "N":
           // TODO:
           console.log("TODO: handle notice");
-          console.info(`Notices are not yet fully implemented, however here is the message received as a string:\n${msg.reader.readString(msg.byteCount)}`);
+          console.info(
+            `Notices are not yet fully implemented, however here is the message received as a string:\n${
+              msg.reader.readString(msg.byteCount)
+            }`,
+          );
           result.done();
           break;
         default:

--- a/connection.ts
+++ b/connection.ts
@@ -339,6 +339,12 @@ export class Connection {
         case "E":
           await this._processError(msg);
           break;
+        case "N":
+          // TODO:
+          console.log("TODO: handle notice");
+          console.info(`Notices are not yet fully implemented, however here is the message received as a string:\n${msg.reader.readString(msg.byteCount)}`);
+          result.done();
+          break;
         default:
           throw new Error(`Unexpected frame: ${msg.type}`);
       }


### PR DESCRIPTION
Hey all, I did a bit of searching and did not find much around this topic, so I hope this commit is something of value to the repository.

I noticed I had queries crashing when running SQL statements that would do things like `CREATE TABLE IF NOT EXISTS table_name …` and `table_name` already existed. I poked around a bit until I found a way to display the notices and not have the query throw an exception.

Normally I would add a test in this case, but since we aren't returning anything to the user I did not see a straight forward path to do that. If you have any suggestions I would be happy to amend the pull request to add tests. Below is the original commit message from my fork just incase it adds context or value.

**Original commit:**

> log a message saying that notices are not supported, but print what the notice is.
> 
> this handles two cases:
> first it prevents the client from crashing on notices
> second it logs the message to the user in case it is useful to them