### PR TITLE
Decouple query as array and as object

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -4,6 +4,7 @@ import {
   Query,
   QueryArrayResult,
   QueryConfig,
+  QueryObjectConfig,
   QueryObjectResult,
 } from "./query.ts";
 
@@ -20,16 +21,26 @@ class BaseClient {
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<QueryArrayResult> {
-    const query = new Query(text, ...args);
+    let query;
+    if (typeof text === "string") {
+      query = new Query(text, ...args);
+    } else {
+      query = new Query(text);
+    }
     return await this._connection.query(query, "array");
   }
 
   async queryObject(
-    text: string | QueryConfig,
+    text: string | QueryObjectConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<QueryObjectResult> {
-    const query = new Query(text, ...args);
+    let query;
+    if (typeof text === "string") {
+      query = new Query(text, ...args);
+    } else {
+      query = new Query(text);
+    }
     return await this._connection.query(query, "object");
   }
 }

--- a/client.ts
+++ b/client.ts
@@ -1,6 +1,11 @@
 import { Connection } from "./connection.ts";
 import { ConnectionOptions, createParams } from "./connection_params.ts";
-import { Query, QueryArrayResult, QueryConfig } from "./query.ts";
+import {
+  Query,
+  QueryArrayResult,
+  QueryConfig,
+  QueryObjectResult,
+} from "./query.ts";
 
 export class Client {
   protected _connection: Connection;
@@ -29,11 +34,13 @@ export class Client {
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<QueryArrayResult> {
+  ): Promise<QueryObjectResult> {
     const query = new Query(text, ...args);
     return await this._connection.query(query, "object");
   }
 
+  //TODO
+  //Objectify
   async multiQuery(queries: QueryConfig[]): Promise<QueryArrayResult[]> {
     const result: QueryArrayResult[] = [];
 

--- a/client.ts
+++ b/client.ts
@@ -44,8 +44,12 @@ export class Client extends BaseClient {
     await this._connection.initSQL();
   }
 
-  //TODO
-  //Objectify
+  /**
+   * This method executes one query after another and the returns an array-like
+   * result for each query
+   * 
+   * @deprecated Quite possibly going to be removed before 1.0
+   * */
   async multiQuery(queries: QueryConfig[]): Promise<QueryArrayResult[]> {
     const result: QueryArrayResult[] = [];
 

--- a/client.ts
+++ b/client.ts
@@ -1,6 +1,6 @@
 import { Connection } from "./connection.ts";
 import { ConnectionOptions, createParams } from "./connection_params.ts";
-import { Query, QueryConfig, QueryResult } from "./query.ts";
+import { Query, QueryArrayResult, QueryConfig } from "./query.ts";
 
 export class Client {
   protected _connection: Connection;
@@ -20,13 +20,22 @@ export class Client {
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<QueryResult> {
+  ): Promise<QueryArrayResult> {
     const query = new Query(text, ...args);
-    return await this._connection.query(query);
+    return await this._connection.query(query, "array");
   }
 
-  async multiQuery(queries: QueryConfig[]): Promise<QueryResult[]> {
-    const result: QueryResult[] = [];
+  async queryObject(
+    text: string | QueryConfig,
+    // deno-lint-ignore no-explicit-any
+    ...args: any[]
+  ): Promise<QueryArrayResult> {
+    const query = new Query(text, ...args);
+    return await this._connection.query(query, "object");
+  }
+
+  async multiQuery(queries: QueryConfig[]): Promise<QueryArrayResult[]> {
+    const result: QueryArrayResult[] = [];
 
     for (const query of queries) {
       result.push(await this.queryArray(query));
@@ -53,13 +62,13 @@ export class PoolClient {
     this._releaseCallback = releaseCallback;
   }
 
-  async query(
+  async queryArray(
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<QueryResult> {
+  ): Promise<QueryArrayResult> {
     const query = new Query(text, ...args);
-    return await this._connection.query(query);
+    return await this._connection.query(query, "array");
   }
 
   async release(): Promise<void> {

--- a/client.ts
+++ b/client.ts
@@ -16,7 +16,7 @@ export class Client {
   }
 
   // TODO: can we use more specific type for args?
-  async query(
+  async queryArray(
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
@@ -29,7 +29,7 @@ export class Client {
     const result: QueryResult[] = [];
 
     for (const query of queries) {
-      result.push(await this.query(query));
+      result.push(await this.queryArray(query));
     }
 
     return result;

--- a/connection.ts
+++ b/connection.ts
@@ -619,6 +619,8 @@ export class Connection {
     return new RowDescription(columnCount, columns);
   }
 
+  //TODO
+  //Research corner cases where _readDataRow can return null values
   // deno-lint-ignore no-explicit-any
   _readDataRow(msg: Message): any[] {
     const fieldCount = msg.reader.readInt16();

--- a/connection.ts
+++ b/connection.ts
@@ -284,7 +284,7 @@ export class Connection {
     await this.bufWriter.write(buffer);
     await this.bufWriter.flush();
 
-    const result = query.result;
+    const result = new QueryResult(query);
 
     let msg: Message;
 
@@ -501,7 +501,7 @@ export class Connection {
     await this._readParseComplete();
     await this._readBindComplete();
 
-    const result = query.result;
+    const result = new QueryResult(query);
     let msg: Message;
     msg = await this.readMessage();
 

--- a/connection.ts
+++ b/connection.ts
@@ -385,9 +385,7 @@ export class Connection {
   async _sendBindMessage(query: Query) {
     this.packetWriter.clear();
 
-    const hasBinaryArgs = query.args.reduce((prev, curr) => {
-      return prev || curr instanceof Uint8Array;
-    }, false);
+    const hasBinaryArgs = query.args.some((arg) => arg instanceof Uint8Array);
 
     // bind statement
     this.packetWriter.clear();

--- a/connection.ts
+++ b/connection.ts
@@ -290,10 +290,11 @@ export class Connection {
 
     msg = await this.readMessage();
 
+    // Query startup message, executed only once
     switch (msg.type) {
       // row description
       case "T":
-        result.handleRowDescription(this._processRowDescription(msg));
+        result.loadColumnDescriptions(this._processRowDescription(msg));
         break;
       // no data
       case "n":
@@ -318,6 +319,7 @@ export class Connection {
         throw new Error(`Unexpected frame: ${msg.type}`);
     }
 
+    // Handle each row returned by the query
     while (true) {
       msg = await this.readMessage();
       switch (msg.type) {
@@ -509,7 +511,7 @@ export class Connection {
       // row description
       case "T": {
         const rowDescription = this._processRowDescription(msg);
-        result.handleRowDescription(rowDescription);
+        result.loadColumnDescriptions(rowDescription);
         break;
       }
       // no data

--- a/connection.ts
+++ b/connection.ts
@@ -41,8 +41,6 @@ import {
 } from "./query.ts";
 import type { ConnectionParams } from "./connection_params.ts";
 
-type ParseType = "array" | "object";
-
 export enum Format {
   TEXT = 0,
   BINARY = 1,
@@ -285,9 +283,9 @@ export class Connection {
 
   //TODO
   //Refactor the conditional return
-  private async _simpleQuery<T extends ParseType>(
+  private async _simpleQuery<T extends "array" | "object">(
     query: Query,
-    type: ParseType,
+    type: "array" | "object",
   ): Promise<T extends "array" ? QueryArrayResult : QueryObjectResult> {
     this.packetWriter.clear();
 
@@ -509,7 +507,7 @@ export class Connection {
 
   // TODO: I believe error handling here is not correct, shouldn't 'sync' message be
   //  sent after error response is received in prepared statements?
-  async _preparedQuery<T extends ParseType>(
+  async _preparedQuery<T extends "array" | "object">(
     query: Query,
     type: T,
   ): Promise<T extends "array" ? QueryArrayResult : QueryObjectResult> {
@@ -583,9 +581,10 @@ export class Connection {
     return result as T extends "array" ? QueryArrayResult : QueryObjectResult;
   }
 
-  async query(query: Query, type: "array"): Promise<QueryArrayResult>;
-  async query(query: Query, type: "object"): Promise<QueryObjectResult>;
-  async query(query: Query, type: ParseType) {
+  async query<T extends "array" | "object">(
+    query: Query,
+    type: T,
+  ): Promise<T extends "array" ? QueryArrayResult : QueryObjectResult> {
     await this._queryLock.pop();
     try {
       if (query.args.length === 0) {

--- a/connection.ts
+++ b/connection.ts
@@ -33,8 +33,15 @@ import { hashMd5Password, readUInt32BE } from "./utils.ts";
 import { PacketReader } from "./packet_reader.ts";
 import { PacketWriter } from "./packet_writer.ts";
 import { parseError, parseNotice } from "./warning.ts";
-import { Query, QueryConfig, QueryResult } from "./query.ts";
+import {
+  Query,
+  QueryArrayResult,
+  QueryConfig,
+  QueryObjectResult,
+} from "./query.ts";
 import type { ConnectionParams } from "./connection_params.ts";
+
+type ParseType = "array" | "object";
 
 export enum Format {
   TEXT = 0,
@@ -276,7 +283,12 @@ export class Connection {
     this._processReadyForQuery(msg);
   }
 
-  private async _simpleQuery(query: Query): Promise<QueryResult> {
+  //TODO
+  //Refactor the conditional return
+  private async _simpleQuery<T extends ParseType>(
+    query: Query,
+    type: ParseType,
+  ): Promise<T extends "array" ? QueryArrayResult : QueryObjectResult> {
     this.packetWriter.clear();
 
     const buffer = this.packetWriter.addCString(query.text).flush(0x51);
@@ -284,7 +296,12 @@ export class Connection {
     await this.bufWriter.write(buffer);
     await this.bufWriter.flush();
 
-    const result = new QueryResult(query);
+    let result;
+    if (type === "array") {
+      result = new QueryArrayResult(query);
+    } else {
+      result = new QueryObjectResult(query);
+    }
 
     let msg: Message;
 
@@ -327,7 +344,7 @@ export class Connection {
         case "D": {
           // this is actually packet read
           const foo = this._readDataRow(msg);
-          result.handleDataRow(foo);
+          result.insertRow(foo);
           break;
         }
         // command complete
@@ -340,7 +357,8 @@ export class Connection {
         // ready for query
         case "Z":
           this._processReadyForQuery(msg);
-          return result;
+          // deno-lint-ignore no-explicit-any
+          return result as any;
         // error response
         case "E":
           await this._processError(msg);
@@ -491,7 +509,7 @@ export class Connection {
 
   // TODO: I believe error handling here is not correct, shouldn't 'sync' message be
   //  sent after error response is received in prepared statements?
-  async _preparedQuery(query: Query): Promise<QueryResult> {
+  async _preparedQuery(query: Query): Promise<QueryArrayResult> {
     await this._sendPrepareMessage(query);
     await this._sendBindMessage(query);
     await this._sendDescribeMessage();
@@ -503,7 +521,7 @@ export class Connection {
     await this._readParseComplete();
     await this._readBindComplete();
 
-    const result = new QueryResult(query);
+    const result = new QueryArrayResult(query);
     let msg: Message;
     msg = await this.readMessage();
 
@@ -533,7 +551,7 @@ export class Connection {
         case "D": {
           // this is actually packet read
           const rawDataRow = this._readDataRow(msg);
-          result.handleDataRow(rawDataRow);
+          result.insertRow(rawDataRow);
           break;
         }
         // command complete
@@ -557,11 +575,14 @@ export class Connection {
     return result;
   }
 
-  async query(query: Query): Promise<QueryResult> {
+  // async query(query: Query, type: "array"): Promise<QueryArrayResult>;
+  // async query(query: Query, type: "object"): Promise<QueryObjectResult>;
+  // deno-lint-ignore no-explicit-any
+  async query(query: Query, type: ParseType): Promise<any> {
     await this._queryLock.pop();
     try {
       if (query.args.length === 0) {
-        return await this._simpleQuery(query);
+        return await this._simpleQuery(query, type);
       } else {
         return await this._preparedQuery(query);
       }
@@ -619,7 +640,7 @@ export class Connection {
   async initSQL(): Promise<void> {
     const config: QueryConfig = { text: "select 1;", args: [] };
     const query = new Query(config);
-    await this.query(query);
+    await this.query(query, "array");
   }
 
   async end(): Promise<void> {

--- a/pool.ts
+++ b/pool.ts
@@ -10,6 +10,7 @@ import {
   Query,
   QueryArrayResult,
   QueryConfig,
+  QueryObjectConfig,
   QueryObjectResult,
 } from "./query.ts";
 
@@ -108,7 +109,12 @@ export class Pool {
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<QueryArrayResult> {
-    const query = new Query(text, ...args);
+    let query;
+    if (typeof text === "string") {
+      query = new Query(text, ...args);
+    } else {
+      query = new Query(text);
+    }
     return await this._execute(query, "array");
   }
 
@@ -117,7 +123,12 @@ export class Pool {
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<QueryObjectResult> {
-    const query = new Query(text, ...args);
+    let query;
+    if (typeof text === "string") {
+      query = new Query(text, ...args);
+    } else {
+      query = new Query(text);
+    }
     return await this._execute(query, "object");
   }
 

--- a/pool.ts
+++ b/pool.ts
@@ -119,7 +119,7 @@ export class Pool {
   }
 
   async queryObject(
-    text: string | QueryConfig,
+    text: string | QueryObjectConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
   ): Promise<QueryObjectResult> {

--- a/pool.ts
+++ b/pool.ts
@@ -6,7 +6,7 @@ import {
   createParams,
 } from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";
-import { Query, QueryConfig, QueryResult } from "./query.ts";
+import { Query, QueryArrayResult, QueryConfig } from "./query.ts";
 
 export class Pool {
   private _connectionParams: ConnectionParams;
@@ -68,11 +68,11 @@ export class Pool {
     );
   }
 
-  private async _execute(query: Query): Promise<QueryResult> {
+  private async _execute(query: Query): Promise<QueryArrayResult> {
     await this.ready;
     const connection = await this._availableConnections.pop();
     try {
-      const result = await connection.query(query);
+      const result = await connection.query(query, "array");
       return result;
     } catch (error) {
       throw error;
@@ -89,11 +89,11 @@ export class Pool {
   }
 
   // TODO: can we use more specific type for args?
-  async query(
+  async queryArray(
     text: string | QueryConfig,
     // deno-lint-ignore no-explicit-any
     ...args: any[]
-  ): Promise<QueryResult> {
+  ): Promise<QueryArrayResult> {
     const query = new Query(text, ...args);
     return await this._execute(query);
   }

--- a/pool.ts
+++ b/pool.ts
@@ -6,8 +6,15 @@ import {
   createParams,
 } from "./connection_params.ts";
 import { DeferredStack } from "./deferred.ts";
-import { Query, QueryArrayResult, QueryConfig } from "./query.ts";
+import {
+  Query,
+  QueryArrayResult,
+  QueryConfig,
+  QueryObjectResult,
+} from "./query.ts";
 
+// TODO
+// This whole construct might be redundant to PoolClient
 export class Pool {
   private _connectionParams: ConnectionParams;
   private _connections!: Array<Connection>;
@@ -68,12 +75,19 @@ export class Pool {
     );
   }
 
-  private async _execute(query: Query): Promise<QueryArrayResult> {
+  private async _execute(
+    query: Query,
+    type: "array",
+  ): Promise<QueryArrayResult>;
+  private async _execute(
+    query: Query,
+    type: "object",
+  ): Promise<QueryObjectResult>;
+  private async _execute(query: Query, type: "array" | "object") {
     await this.ready;
     const connection = await this._availableConnections.pop();
     try {
-      const result = await connection.query(query, "array");
-      return result;
+      return await connection.query(query, type);
     } catch (error) {
       throw error;
     } finally {
@@ -95,7 +109,16 @@ export class Pool {
     ...args: any[]
   ): Promise<QueryArrayResult> {
     const query = new Query(text, ...args);
-    return await this._execute(query);
+    return await this._execute(query, "array");
+  }
+
+  async queryObject(
+    text: string | QueryConfig,
+    // deno-lint-ignore no-explicit-any
+    ...args: any[]
+  ): Promise<QueryObjectResult> {
+    const query = new Query(text, ...args);
+    return await this._execute(query, "object");
   }
 
   async end(): Promise<void> {

--- a/query.ts
+++ b/query.ts
@@ -86,18 +86,6 @@ export class QueryArrayResult extends QueryResult {
     const parsedRow = this.parseRowData(row);
     this.rows.push(parsedRow);
   }
-
-  rowsOfObjects() {
-    return this.rows.map((row) => {
-      // deno-lint-ignore no-explicit-any
-      const rv: { [key: string]: any } = {};
-      this.rowDescription.columns.forEach((column, index) => {
-        rv[column.name] = row[index];
-      });
-
-      return rv;
-    });
-  }
 }
 
 export class QueryObjectResult extends QueryResult {

--- a/query.ts
+++ b/query.ts
@@ -85,7 +85,9 @@ export class QueryArrayResult extends QueryResult {
 
   insertRow(row: Uint8Array[]): void {
     if (this._done) {
-      throw new Error("New data row, after result if done.");
+      throw new Error(
+        "Tried to add a new row to the result after the result is done reading",
+      );
     }
 
     const parsedRow = this.parseRowData(row);
@@ -122,7 +124,9 @@ export class QueryObjectResult extends QueryResult {
 
   insertRow(row: Uint8Array[]): void {
     if (this._done) {
-      throw new Error("New data row, after result if done.");
+      throw new Error(
+        "Tried to add a new row to the result after the result is done reading",
+      );
     }
 
     const parsedRow = this.parseRowData(row);

--- a/query.ts
+++ b/query.ts
@@ -96,10 +96,83 @@ export class QueryResult {
   }
 }
 
+export class ObjectQueryResult {
+  private _done = false;
+  public command!: CommandType;
+  public rowCount?: number;
+  public rowDescription!: RowDescription;
+  // deno-lint-ignore no-explicit-any
+  public rows: any[] = []; // actual results
+  public warnings: WarningFields[] = [];
+
+  constructor(public query: Query) {}
+
+  handleRowDescription(description: RowDescription) {
+    this.rowDescription = description;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  private _parseDataRow(dataRow: any[]): any[] {
+    const parsedRow = [];
+
+    for (let i = 0, len = dataRow.length; i < len; i++) {
+      const column = this.rowDescription.columns[i];
+      const rawValue = dataRow[i];
+
+      if (rawValue === null) {
+        parsedRow.push(null);
+      } else {
+        parsedRow.push(decode(rawValue, column));
+      }
+    }
+
+    return parsedRow;
+  }
+
+  // deno-lint-ignore no-explicit-any
+  handleDataRow(dataRow: any[]): void {
+    if (this._done) {
+      throw new Error("New data row, after result if done.");
+    }
+
+    const parsedRow = this._parseDataRow(dataRow);
+    this.rows.push(parsedRow);
+  }
+
+  handleCommandComplete(commandTag: string): void {
+    const match = commandTagRegexp.exec(commandTag);
+    if (match) {
+      this.command = match[1] as CommandType;
+      if (match[3]) {
+        // COMMAND OID ROWS
+        this.rowCount = parseInt(match[3], 10);
+      } else {
+        // COMMAND ROWS
+        this.rowCount = parseInt(match[2], 10);
+      }
+    }
+  }
+
+  rowsOfObjects() {
+    return this.rows.map((row) => {
+      // deno-lint-ignore no-explicit-any
+      const rv: { [key: string]: any } = {};
+      this.rowDescription.columns.forEach((column, index) => {
+        rv[column.name] = row[index];
+      });
+
+      return rv;
+    });
+  }
+
+  done() {
+    this._done = true;
+  }
+}
+
 export class Query {
   public text: string;
   public args: EncodedArg[];
-  public result: QueryResult;
 
   // TODO: can we use more specific type for args?
   constructor(text: string | QueryConfig, ...args: unknown[]) {
@@ -111,7 +184,6 @@ export class Query {
     }
     this.text = config.text;
     this.args = this._prepareArgs(config);
-    this.result = new QueryResult(this);
   }
 
   private _prepareArgs(config: QueryConfig): EncodedArg[] {

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -6,22 +6,22 @@ function getRandomString() {
   return Math.random().toString(36).substring(7);
 }
 
-Deno.test("badAuthData", async function () {
-  const badConnectionData = { ...TEST_CONNECTION_PARAMS };
-  badConnectionData.password += getRandomString();
-  const client = new Client(badConnectionData);
+// Deno.test("badAuthData", async function () {
+//   const badConnectionData = { ...TEST_CONNECTION_PARAMS };
+//   badConnectionData.password += getRandomString();
+//   const client = new Client(badConnectionData);
 
-  await assertThrowsAsync(
-    async (): Promise<void> => {
-      await client.connect();
-    },
-    PostgresError,
-    "password authentication failed for user",
-  )
-    .finally(async () => {
-      await client.end();
-    });
-});
+//   await assertThrowsAsync(
+//     async (): Promise<void> => {
+//       await client.connect();
+//     },
+//     PostgresError,
+//     "password authentication failed for user",
+//   )
+//     .finally(async () => {
+//       await client.end();
+//     });
+// });
 
 Deno.test("startupError", async function () {
   const badConnectionData = { ...TEST_CONNECTION_PARAMS };

--- a/tests/client.ts
+++ b/tests/client.ts
@@ -6,22 +6,22 @@ function getRandomString() {
   return Math.random().toString(36).substring(7);
 }
 
-// Deno.test("badAuthData", async function () {
-//   const badConnectionData = { ...TEST_CONNECTION_PARAMS };
-//   badConnectionData.password += getRandomString();
-//   const client = new Client(badConnectionData);
+Deno.test("badAuthData", async function () {
+  const badConnectionData = { ...TEST_CONNECTION_PARAMS };
+  badConnectionData.password += getRandomString();
+  const client = new Client(badConnectionData);
 
-//   await assertThrowsAsync(
-//     async (): Promise<void> => {
-//       await client.connect();
-//     },
-//     PostgresError,
-//     "password authentication failed for user",
-//   )
-//     .finally(async () => {
-//       await client.end();
-//     });
-// });
+  await assertThrowsAsync(
+    async (): Promise<void> => {
+      await client.connect();
+    },
+    PostgresError,
+    "password authentication failed for user",
+  )
+    .finally(async () => {
+      await client.end();
+    });
+});
 
 Deno.test("startupError", async function () {
   const badConnectionData = { ...TEST_CONNECTION_PARAMS };

--- a/tests/data_types.ts
+++ b/tests/data_types.ts
@@ -18,11 +18,11 @@ const testClient = getTestClient(CLIENT, SETUP);
 
 testClient(async function inet() {
   const inet = "127.0.0.1";
-  await CLIENT.query(
+  await CLIENT.queryArray(
     "INSERT INTO data_types (inet_t) VALUES($1)",
     inet,
   );
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT inet_t FROM data_types WHERE inet_t=$1",
     inet,
   );
@@ -30,14 +30,14 @@ testClient(async function inet() {
 });
 
 testClient(async function inetArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{ 127.0.0.1, 192.168.178.0/24 }'::inet[]",
   );
   assertEquals(selectRes.rows[0], [["127.0.0.1", "192.168.178.0/24"]]);
 });
 
 testClient(async function inetNestedArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{{127.0.0.1},{192.168.178.0/24}}'::inet[]",
   );
   assertEquals(selectRes.rows[0], [[["127.0.0.1"], ["192.168.178.0/24"]]]);
@@ -45,11 +45,11 @@ testClient(async function inetNestedArray() {
 
 testClient(async function macaddr() {
   const macaddr = "08:00:2b:01:02:03";
-  await CLIENT.query(
+  await CLIENT.queryArray(
     "INSERT INTO data_types (macaddr_t) VALUES($1)",
     macaddr,
   );
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT macaddr_t FROM data_types WHERE macaddr_t=$1",
     macaddr,
   );
@@ -57,14 +57,14 @@ testClient(async function macaddr() {
 });
 
 testClient(async function macaddrArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{ 08:00:2b:01:02:03, 09:00:2b:01:02:04 }'::macaddr[]",
   );
   assertEquals(selectRes.rows[0], [["08:00:2b:01:02:03", "09:00:2b:01:02:04"]]);
 });
 
 testClient(async function macaddrNestedArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{{08:00:2b:01:02:03},{09:00:2b:01:02:04}}'::macaddr[]",
   );
   assertEquals(
@@ -75,11 +75,11 @@ testClient(async function macaddrNestedArray() {
 
 testClient(async function cidr() {
   const cidr = "192.168.100.128/25";
-  await CLIENT.query(
+  await CLIENT.queryArray(
     "INSERT INTO data_types (cidr_t) VALUES($1)",
     cidr,
   );
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT cidr_t FROM data_types WHERE cidr_t=$1",
     cidr,
   );
@@ -87,104 +87,106 @@ testClient(async function cidr() {
 });
 
 testClient(async function cidrArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{ 10.1.0.0/16, 11.11.11.0/24 }'::cidr[]",
   );
   assertEquals(selectRes.rows[0], [["10.1.0.0/16", "11.11.11.0/24"]]);
 });
 
 testClient(async function cidrNestedArray() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT '{{10.1.0.0/16},{11.11.11.0/24}}'::cidr[]",
   );
   assertEquals(selectRes.rows[0], [[["10.1.0.0/16"], ["11.11.11.0/24"]]]);
 });
 
 testClient(async function name() {
-  const result = await CLIENT.query(`SELECT 'some'::name`);
+  const result = await CLIENT.queryArray(`SELECT 'some'::name`);
   assertEquals(result.rows[0][0], "some");
 });
 
 testClient(async function nameArray() {
-  const result = await CLIENT.query(`SELECT ARRAY['some'::name, 'none']`);
+  const result = await CLIENT.queryArray(`SELECT ARRAY['some'::name, 'none']`);
   assertEquals(result.rows[0][0], ["some", "none"]);
 });
 
 testClient(async function oid() {
-  const result = await CLIENT.query(`SELECT 1::oid`);
+  const result = await CLIENT.queryArray(`SELECT 1::oid`);
   assertEquals(result.rows[0][0], "1");
 });
 
 testClient(async function oidArray() {
-  const result = await CLIENT.query(`SELECT ARRAY[1::oid, 452, 1023]`);
+  const result = await CLIENT.queryArray(`SELECT ARRAY[1::oid, 452, 1023]`);
   assertEquals(result.rows[0][0], ["1", "452", "1023"]);
 });
 
 testClient(async function regproc() {
-  const result = await CLIENT.query(`SELECT 'now'::regproc`);
+  const result = await CLIENT.queryArray(`SELECT 'now'::regproc`);
   assertEquals(result.rows[0][0], "now");
 });
 
 testClient(async function regprocArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['now'::regproc, 'timeofday']`,
   );
   assertEquals(result.rows[0][0], ["now", "timeofday"]);
 });
 
 testClient(async function regprocedure() {
-  const result = await CLIENT.query(`SELECT 'sum(integer)'::regprocedure`);
+  const result = await CLIENT.queryArray(`SELECT 'sum(integer)'::regprocedure`);
   assertEquals(result.rows[0][0], "sum(integer)");
 });
 
 testClient(async function regprocedureArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['sum(integer)'::regprocedure, 'max(integer)']`,
   );
   assertEquals(result.rows[0][0], ["sum(integer)", "max(integer)"]);
 });
 
 testClient(async function regoper() {
-  const result = await CLIENT.query(`SELECT '!'::regoper`);
+  const result = await CLIENT.queryArray(`SELECT '!'::regoper`);
   assertEquals(result.rows[0][0], "!");
 });
 
 testClient(async function regoperArray() {
-  const result = await CLIENT.query(`SELECT ARRAY['!'::regoper]`);
+  const result = await CLIENT.queryArray(`SELECT ARRAY['!'::regoper]`);
   assertEquals(result.rows[0][0], ["!"]);
 });
 
 testClient(async function regoperator() {
-  const result = await CLIENT.query(`SELECT '!(bigint,NONE)'::regoperator`);
+  const result = await CLIENT.queryArray(
+    `SELECT '!(bigint,NONE)'::regoperator`,
+  );
   assertEquals(result.rows[0][0], "!(bigint,NONE)");
 });
 
 testClient(async function regoperatorArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['!(bigint,NONE)'::regoperator, '*(integer,integer)']`,
   );
   assertEquals(result.rows[0][0], ["!(bigint,NONE)", "*(integer,integer)"]);
 });
 
 testClient(async function regclass() {
-  const result = await CLIENT.query(`SELECT 'data_types'::regclass`);
+  const result = await CLIENT.queryArray(`SELECT 'data_types'::regclass`);
   assertEquals(result.rows, [["data_types"]]);
 });
 
 testClient(async function regclassArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['data_types'::regclass, 'pg_type']`,
   );
   assertEquals(result.rows[0][0], ["data_types", "pg_type"]);
 });
 
 testClient(async function regtype() {
-  const result = await CLIENT.query(`SELECT 'integer'::regtype`);
+  const result = await CLIENT.queryArray(`SELECT 'integer'::regtype`);
   assertEquals(result.rows[0][0], "integer");
 });
 
 testClient(async function regtypeArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['integer'::regtype, 'bigint']`,
   );
   assertEquals(result.rows[0][0], ["integer", "bigint"]);
@@ -195,7 +197,7 @@ testClient(async function regtypeArray() {
 testClient(async function regrole() {
   const user = TEST_CONNECTION_PARAMS.user || Deno.env.get("PGUSER");
 
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ($1)::regrole`,
     user,
   );
@@ -208,7 +210,7 @@ testClient(async function regrole() {
 testClient(async function regroleArray() {
   const user = TEST_CONNECTION_PARAMS.user || Deno.env.get("PGUSER");
 
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY[($1)::regrole]`,
     user,
   );
@@ -217,46 +219,48 @@ testClient(async function regroleArray() {
 });
 
 testClient(async function regnamespace() {
-  const result = await CLIENT.query(`SELECT 'public'::regnamespace;`);
+  const result = await CLIENT.queryArray(`SELECT 'public'::regnamespace;`);
   assertEquals(result.rows[0][0], "public");
 });
 
 testClient(async function regnamespaceArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['public'::regnamespace, 'pg_catalog'];`,
   );
   assertEquals(result.rows[0][0], ["public", "pg_catalog"]);
 });
 
 testClient(async function regconfig() {
-  const result = await CLIENT.query(`SElECT 'english'::regconfig`);
+  const result = await CLIENT.queryArray(`SElECT 'english'::regconfig`);
   assertEquals(result.rows, [["english"]]);
 });
 
 testClient(async function regconfigArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SElECT ARRAY['english'::regconfig, 'spanish']`,
   );
   assertEquals(result.rows[0][0], ["english", "spanish"]);
 });
 
 testClient(async function regdictionary() {
-  const result = await CLIENT.query("SELECT 'simple'::regdictionary");
+  const result = await CLIENT.queryArray("SELECT 'simple'::regdictionary");
   assertEquals(result.rows[0][0], "simple");
 });
 
 testClient(async function regdictionaryArray() {
-  const result = await CLIENT.query("SELECT ARRAY['simple'::regdictionary]");
+  const result = await CLIENT.queryArray(
+    "SELECT ARRAY['simple'::regdictionary]",
+  );
   assertEquals(result.rows[0][0], ["simple"]);
 });
 
 testClient(async function bigint() {
-  const result = await CLIENT.query("SELECT 9223372036854775807");
+  const result = await CLIENT.queryArray("SELECT 9223372036854775807");
   assertEquals(result.rows[0][0], 9223372036854775807n);
 });
 
 testClient(async function bigintArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     "SELECT ARRAY[9223372036854775807, 789141]",
   );
   assertEquals(result.rows[0][0], [9223372036854775807n, 789141n]);
@@ -264,13 +268,13 @@ testClient(async function bigintArray() {
 
 testClient(async function numeric() {
   const numeric = "1234567890.1234567890";
-  const result = await CLIENT.query(`SELECT $1::numeric`, numeric);
+  const result = await CLIENT.queryArray(`SELECT $1::numeric`, numeric);
   assertEquals(result.rows, [[numeric]]);
 });
 
 testClient(async function numericArray() {
   const numeric = ["1234567890.1234567890", "6107693.123123124"];
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY[$1::numeric, $2]`,
     numeric[0],
     numeric[1],
@@ -279,72 +283,72 @@ testClient(async function numericArray() {
 });
 
 testClient(async function integerArray() {
-  const result = await CLIENT.query("SELECT '{1,100}'::int[]");
+  const result = await CLIENT.queryArray("SELECT '{1,100}'::int[]");
   assertEquals(result.rows[0], [[1, 100]]);
 });
 
 testClient(async function integerNestedArray() {
-  const result = await CLIENT.query("SELECT '{{1},{100}}'::int[]");
+  const result = await CLIENT.queryArray("SELECT '{{1},{100}}'::int[]");
   assertEquals(result.rows[0], [[[1], [100]]]);
 });
 
 testClient(async function char() {
-  await CLIENT.query(
+  await CLIENT.queryArray(
     `CREATE TEMP TABLE CHAR_TEST (X CHARACTER(2));`,
   );
-  await CLIENT.query(
+  await CLIENT.queryArray(
     `INSERT INTO CHAR_TEST (X) VALUES ('A');`,
   );
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT X FROM CHAR_TEST`,
   );
   assertEquals(result.rows[0][0], "A ");
 });
 
 testClient(async function charArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{"x","Y"}'::char[]`,
   );
   assertEquals(result.rows[0][0], ["x", "Y"]);
 });
 
 testClient(async function text() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT 'ABCD'::text`,
   );
   assertEquals(result.rows[0][0], "ABCD");
 });
 
 testClient(async function textArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{"(ZYX)-123-456","(ABC)-987-654"}'::text[]`,
   );
   assertEquals(result.rows[0], [["(ZYX)-123-456", "(ABC)-987-654"]]);
 });
 
 testClient(async function textNestedArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{{"(ZYX)-123-456"},{"(ABC)-987-654"}}'::text[]`,
   );
   assertEquals(result.rows[0], [[["(ZYX)-123-456"], ["(ABC)-987-654"]]]);
 });
 
 testClient(async function varchar() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT 'ABC'::varchar`,
   );
   assertEquals(result.rows[0][0], "ABC");
 });
 
 testClient(async function varcharArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{"(ZYX)-(PQR)-456","(ABC)-987-(?=+)"}'::varchar[]`,
   );
   assertEquals(result.rows[0], [["(ZYX)-(PQR)-456", "(ABC)-987-(?=+)"]]);
 });
 
 testClient(async function varcharNestedArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{{"(ZYX)-(PQR)-456"},{"(ABC)-987-(?=+)"}}'::varchar[]`,
   );
   assertEquals(result.rows[0], [[["(ZYX)-(PQR)-456"], ["(ABC)-987-(?=+)"]]]);
@@ -352,12 +356,12 @@ testClient(async function varcharNestedArray() {
 
 testClient(async function uuid() {
   const uuid = "c4792ecb-c00a-43a2-bd74-5b0ed551c599";
-  const result = await CLIENT.query(`SELECT $1::uuid`, uuid);
+  const result = await CLIENT.queryArray(`SELECT $1::uuid`, uuid);
   assertEquals(result.rows, [[uuid]]);
 });
 
 testClient(async function uuidArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{"c4792ecb-c00a-43a2-bd74-5b0ed551c599",
       "c9dd159e-d3d7-4bdf-b0ea-e51831c28e9b"}'::uuid[]`,
   );
@@ -371,7 +375,7 @@ testClient(async function uuidArray() {
 });
 
 testClient(async function uuidNestedArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{{"c4792ecb-c00a-43a2-bd74-5b0ed551c599"},
       {"c9dd159e-d3d7-4bdf-b0ea-e51831c28e9b"}}'::uuid[]`,
   );
@@ -385,12 +389,12 @@ testClient(async function uuidNestedArray() {
 });
 
 testClient(async function voidType() {
-  const result = await CLIENT.query("select pg_sleep(0.01)"); // `pg_sleep()` returns void.
+  const result = await CLIENT.queryArray("select pg_sleep(0.01)"); // `pg_sleep()` returns void.
   assertEquals(result.rows, [[""]]);
 });
 
 testClient(async function bpcharType() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     "SELECT cast('U7DV6WQ26D7X2IILX5L4LTYMZUKJ5F3CEDDQV3ZSLQVYNRPX2WUA' as char(52));",
   );
   assertEquals(
@@ -400,19 +404,21 @@ testClient(async function bpcharType() {
 });
 
 testClient(async function bpcharArray() {
-  const result = await CLIENT.query(`SELECT '{"AB1234","4321BA"}'::bpchar[]`);
+  const result = await CLIENT.queryArray(
+    `SELECT '{"AB1234","4321BA"}'::bpchar[]`,
+  );
   assertEquals(result.rows[0], [["AB1234", "4321BA"]]);
 });
 
 testClient(async function bpcharNestedArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT '{{"AB1234"},{"4321BA"}}'::bpchar[]`,
   );
   assertEquals(result.rows[0], [[["AB1234"], ["4321BA"]]]);
 });
 
 testClient(async function jsonArray() {
-  const jsonArray = await CLIENT.query(
+  const jsonArray = await CLIENT.queryArray(
     `SELECT ARRAY_AGG(A) FROM  (
       SELECT JSON_BUILD_OBJECT( 'X', '1' ) AS A
       UNION ALL
@@ -422,7 +428,7 @@ testClient(async function jsonArray() {
 
   assertEquals(jsonArray.rows[0][0], [{ X: "1" }, { Y: "2" }]);
 
-  const jsonArrayNested = await CLIENT.query(
+  const jsonArrayNested = await CLIENT.queryArray(
     `SELECT ARRAY[ARRAY[ARRAY_AGG(A), ARRAY_AGG(A)], ARRAY[ARRAY_AGG(A), ARRAY_AGG(A)]] FROM  (
       SELECT JSON_BUILD_OBJECT( 'X', '1' ) AS A
       UNION ALL
@@ -446,14 +452,14 @@ testClient(async function jsonArray() {
 });
 
 testClient(async function bool() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT bool('y')`,
   );
   assertEquals(result.rows[0][0], true);
 });
 
 testClient(async function boolArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT array[bool('y'), bool('n'), bool('1'), bool('0')]`,
   );
   assertEquals(result.rows[0][0], [true, false, true, false]);
@@ -472,7 +478,7 @@ function randomBase64(): string {
 testClient(async function bytea() {
   const base64 = randomBase64();
 
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT decode('${base64}','base64')`,
   );
 
@@ -485,7 +491,7 @@ testClient(async function byteaArray() {
     randomBase64,
   );
 
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT array[ ${
       strings.map((x) => `decode('${x}', 'base64')`).join(", ")
     } ]`,
@@ -498,28 +504,28 @@ testClient(async function byteaArray() {
 });
 
 testClient(async function point() {
-  const selectRes = await CLIENT.query(
+  const selectRes = await CLIENT.queryArray(
     "SELECT point(1, 2)",
   );
   assertEquals(selectRes.rows, [[{ x: 1, y: 2 }]]);
 });
 
 testClient(async function pointArray() {
-  const result1 = await CLIENT.query(
+  const result1 = await CLIENT.queryArray(
     `SELECT '{"(1, 2)","(3.5, 4.1)"}'::point[]`,
   );
   assertEquals(result1.rows, [
     [[{ x: 1, y: 2 }, { x: 3.5, y: 4.1 }]],
   ]);
 
-  const result2 = await CLIENT.query(
+  const result2 = await CLIENT.queryArray(
     `SELECT array[ point(1,2), point(3.5, 4.1) ]`,
   );
   assertEquals(result2.rows, [
     [[{ x: 1, y: 2 }, { x: 3.5, y: 4.1 }]],
   ]);
 
-  const result3 = await CLIENT.query(
+  const result3 = await CLIENT.queryArray(
     `SELECT array[ array[ point(1,2), point(3.5, 4.1) ], array[ point(25, 50), point(-10, -17.5) ] ]`,
   );
   assertEquals(result3.rows[0], [
@@ -531,13 +537,13 @@ testClient(async function pointArray() {
 });
 
 testClient(async function time() {
-  const result = await CLIENT.query("SELECT '01:01:01'::TIME");
+  const result = await CLIENT.queryArray("SELECT '01:01:01'::TIME");
 
   assertEquals(result.rows[0][0], "01:01:01");
 });
 
 testClient(async function timeArray() {
-  const result = await CLIENT.query("SELECT ARRAY['01:01:01'::TIME]");
+  const result = await CLIENT.queryArray("SELECT ARRAY['01:01:01'::TIME]");
 
   assertEquals(result.rows[0][0], ["01:01:01"]);
 });
@@ -545,13 +551,15 @@ testClient(async function timeArray() {
 const timezone = new Date().toTimeString().slice(12, 17);
 
 testClient(async function timetz() {
-  const result = await CLIENT.query(`SELECT '01:01:01${timezone}'::TIMETZ`);
+  const result = await CLIENT.queryArray(
+    `SELECT '01:01:01${timezone}'::TIMETZ`,
+  );
 
   assertEquals(result.rows[0][0].slice(0, 8), "01:01:01");
 });
 
 testClient(async function timetzArray() {
-  const result = await CLIENT.query(
+  const result = await CLIENT.queryArray(
     `SELECT ARRAY['01:01:01${timezone}'::TIMETZ]`,
   );
 
@@ -559,13 +567,15 @@ testClient(async function timetzArray() {
 });
 
 testClient(async function xid() {
-  const result = await CLIENT.query("SELECT '1'::xid");
+  const result = await CLIENT.queryArray("SELECT '1'::xid");
 
   assertEquals(result.rows[0][0], 1);
 });
 
 testClient(async function xidArray() {
-  const result = await CLIENT.query("SELECT ARRAY['12'::xid, '4789'::xid]");
+  const result = await CLIENT.queryArray(
+    "SELECT ARRAY['12'::xid, '4789'::xid]",
+  );
 
   assertEquals(result.rows[0][0], [12, 4789]);
 });

--- a/tests/helpers.ts
+++ b/tests/helpers.ts
@@ -12,7 +12,7 @@ export function getTestClient(
       try {
         await client.connect();
         for (const q of setupQueries || defSetupQueries || []) {
-          await client.query(q);
+          await client.queryArray(q);
         }
         await t();
       } finally {

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -35,6 +35,41 @@ testPool(async function parametrizedQuery(POOL) {
   assertEquals(result.rows, [{ id: 1 }]);
 });
 
+testPool(async function aliasedObjectQuery(POOL) {
+  const result = await POOL.queryObject({
+    text: "SELECT ARRAY[1, 2, 3], 'DATA'",
+    fields: ["IDS", "type"],
+  });
+
+  assertEquals(result.rows, [{ ids: [1, 2, 3], type: "DATA" }]);
+});
+
+testPool(async function objectQueryThrowsOnRepeatedFields(POOL) {
+  await assertThrowsAsync(
+    async () => {
+      await POOL.queryObject({
+        text: "SELECT 1",
+        fields: ["FIELD_1", "FIELD_1"],
+      });
+    },
+    TypeError,
+    "The fields provided for the query must be unique",
+  );
+});
+
+testPool(async function objectQueryThrowsOnNotMatchingFields(POOL) {
+  await assertThrowsAsync(
+    async () => {
+      await POOL.queryObject({
+        text: "SELECT 1",
+        fields: ["FIELD_1", "FIELD_2"],
+      });
+    },
+    RangeError,
+    "The fields provided for the query don't match the ones returned as a result (1 expected, 2 received)",
+  );
+});
+
 testPool(async function nativeType(POOL) {
   const result = await POOL.queryArray("SELECT * FROM timestamps;");
   const row = result.rows[0];

--- a/tests/pool.ts
+++ b/tests/pool.ts
@@ -31,14 +31,8 @@ testPool(async function simpleQuery(POOL) {
 });
 
 testPool(async function parametrizedQuery(POOL) {
-  const result = await POOL.queryArray("SELECT * FROM ids WHERE id < $1;", 2);
-  assertEquals(result.rows.length, 1);
-
-  const objectRows = result.rowsOfObjects();
-  const row = objectRows[0];
-
-  assertEquals(row.id, 1);
-  assertEquals(typeof row.id, "number");
+  const result = await POOL.queryObject("SELECT * FROM ids WHERE id < $1;", 2);
+  assertEquals(result.rows, [{ id: 1 }]);
 });
 
 testPool(async function nativeType(POOL) {

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -3,7 +3,7 @@ import { assert, assertEquals } from "../test_deps.ts";
 import { DEFAULT_SETUP } from "./constants.ts";
 import TEST_CONNECTION_PARAMS from "./config.ts";
 import { getTestClient } from "./helpers.ts";
-import type { QueryResult } from "../query.ts";
+import type { QueryArrayResult } from "../query.ts";
 
 const CLIENT = new Client(TEST_CONNECTION_PARAMS);
 
@@ -161,7 +161,7 @@ testClient(async function multiQueryWithManyQueryTypeArray() {
 });
 
 testClient(async function resultMetadata() {
-  let result: QueryResult;
+  let result: QueryArrayResult;
 
   // simple select
   result = await CLIENT.queryArray("SELECT * FROM ids WHERE id = 100");

--- a/tests/queries.ts
+++ b/tests/queries.ts
@@ -15,14 +15,11 @@ testClient(async function simpleQuery() {
 });
 
 testClient(async function parametrizedQuery() {
-  const result = await CLIENT.queryArray("SELECT * FROM ids WHERE id < $1;", 2);
-  assertEquals(result.rows.length, 1);
-
-  const objectRows = result.rowsOfObjects();
-  const row = objectRows[0];
-
-  assertEquals(row.id, 1);
-  assertEquals(typeof row.id, "number");
+  const result = await CLIENT.queryObject(
+    "SELECT * FROM ids WHERE id < $1;",
+    2,
+  );
+  assertEquals(result.rows, [{ id: 1 }]);
 });
 
 testClient(async function handleDebugNotice() {


### PR DESCRIPTION
Towards #134

Also this improves performance greatly for object based queries, since you don't have to recast as object with `rowsOfObjects`

- [x] Add parameter in queryObject to map column names