### PR TITLE
feat: Update to Deno 1.7.1 and std 0.85.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Install deno
         uses: denolib/setup-deno@master
         with: 
-          deno-version: 1.7.0
+          deno-version: 1.7.1
 
       - name: Check formatting
         run: deno fmt --check

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
-export { BufReader, BufWriter } from "https://deno.land/std@0.84.0/io/bufio.ts";
-export { copy } from "https://deno.land/std@0.84.0/bytes/mod.ts";
-export { createHash } from "https://deno.land/std@0.84.0/hash/mod.ts";
-export { deferred, delay } from "https://deno.land/std@0.84.0/async/mod.ts";
-export { bold, yellow } from "https://deno.land/std@0.84.0/fmt/colors.ts";
-export type { Deferred } from "https://deno.land/std@0.84.0/async/mod.ts";
+export { BufReader, BufWriter } from "https://deno.land/std@0.85.0/io/bufio.ts";
+export { copy } from "https://deno.land/std@0.85.0/bytes/mod.ts";
+export { createHash } from "https://deno.land/std@0.85.0/hash/mod.ts";
+export { deferred, delay } from "https://deno.land/std@0.85.0/async/mod.ts";
+export { bold, yellow } from "https://deno.land/std@0.85.0/fmt/colors.ts";
+export type { Deferred } from "https://deno.land/std@0.85.0/async/mod.ts";

--- a/test_deps.ts
+++ b/test_deps.ts
@@ -4,12 +4,12 @@ export {
   assertEquals,
   assertThrows,
   assertThrowsAsync,
-} from "https://deno.land/std@0.84.0/testing/asserts.ts";
+} from "https://deno.land/std@0.85.0/testing/asserts.ts";
 export {
   decode as decodeBase64,
   encode as encodeBase64,
-} from "https://deno.land/std@0.84.0/encoding/base64.ts";
+} from "https://deno.land/std@0.85.0/encoding/base64.ts";
 export {
   format as formatDate,
   parse as parseDate,
-} from "https://deno.land/std@0.84.0/datetime/mod.ts";
+} from "https://deno.land/std@0.85.0/datetime/mod.ts";


### PR DESCRIPTION
We are using std 0.85.0, and hope to upgrade the deno version to reduce unnecessary dependencies.