### PR TITLE
feat: Allow postgresql:// dsn.driver for compatibility

### DIFF
--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -2,11 +2,11 @@ import { parseDsn } from "../utils.ts";
 
 /**
  * The connection string must match the following URI structure
- * 
+ *
  * ```ts
  * const connection = "postgres://user:password@hostname:port/database?application_name=application_name";
  * ```
- * 
+ *
  * Password, port and application name are optional parameters
  */
 export type ConnectionString = string;
@@ -14,7 +14,7 @@ export type ConnectionString = string;
 /**
  * This function retrieves the connection options from the environmental variables
  * as they are, without any extra parsing
- * 
+ *
  * It will throw if no env permission was provided on startup
  */
 function getPgEnv(): ConnectionOptions {
@@ -39,7 +39,7 @@ interface TLSOptions {
   /**
    * This will force the connection to run over TLS
    * If the server doesn't support TLS, the connection will fail
-   * 
+   *
    * default: `false`
    * */
   enforce: boolean;
@@ -76,7 +76,7 @@ function formatMissingParams(missingParams: string[]) {
 /**
  * This validates the options passed are defined and have a value other than null
  * or empty string, it throws a connection error otherwise
- * 
+ *
  * @param has_env_access This parameter will change the error message if set to true,
  * telling the user to pass env permissions in order to read environmental variables
  */
@@ -112,7 +112,7 @@ function assertRequiredOptions(
 function parseOptionsFromDsn(connString: string): ConnectionOptions {
   const dsn = parseDsn(connString);
 
-  if (dsn.driver !== "postgres") {
+  if (dsn.driver !== "postgres" && dsn.driver !== "postgresql") {
     throw new ConnectionParamsError(
       `Supplied DSN has invalid driver: ${dsn.driver}.`,
     );

--- a/tests/connection_params_test.ts
+++ b/tests/connection_params_test.ts
@@ -68,7 +68,7 @@ test("dsnStyleParameters", function () {
   assertEquals(p.port, 10101);
 });
 
-test("dsnStyleParametersWithPostgresqlDriver", function() {
+test("dsnStyleParametersWithPostgresqlDriver", function () {
   const p = createParams(
     "postgresql://some_user@some_host:10101/deno_postgres",
   );

--- a/tests/connection_params_test.ts
+++ b/tests/connection_params_test.ts
@@ -11,7 +11,7 @@ import { has_env_access } from "./constants.ts";
  * This function is ment to be used as a container for env based tests.
  * It will mutate the env state and run the callback passed to it, then
  * reset the env variables to it's original state
- * 
+ *
  * It can only be used in tests that run with env permissions
  */
 const withEnv = (env: {
@@ -60,6 +60,17 @@ function withNotAllowedEnv(fn: () => void) {
 test("dsnStyleParameters", function () {
   const p = createParams(
     "postgres://some_user@some_host:10101/deno_postgres",
+  );
+
+  assertEquals(p.database, "deno_postgres");
+  assertEquals(p.user, "some_user");
+  assertEquals(p.hostname, "some_host");
+  assertEquals(p.port, 10101);
+});
+
+test("dsnStyleParametersWithPostgresqlDriver", function() {
+  const p = createParams(
+    "postgresql://some_user@some_host:10101/deno_postgres",
   );
 
   assertEquals(p.database, "deno_postgres");


### PR DESCRIPTION
Adds postgresql:// driver name support to the dsn format for compatibility with other postgresql clients. This can be really handy in situations where DATABASE_URL environment variables are being used and set automatically by the hosting platform.