### PR TITLE
feat: sslmode dsn support

### DIFF
--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -123,9 +123,9 @@ function parseOptionsFromDsn(connString: string): ConnectionOptions {
     const sslmode = dsn.params.sslmode;
     delete dsn.params.sslmode;
 
-    if (sslmode !== "require" && sslmode !== "allow") {
+    if (sslmode !== "require" && sslmode !== "prefer") {
       throw new ConnectionParamsError(
-        `Supplied DSN has invalid sslmode '${sslmode}'. Only 'require' or 'allow' are supported`,
+        `Supplied DSN has invalid sslmode '${sslmode}'. Only 'require' or 'prefer' are supported`,
       );
     }
 

--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -118,8 +118,25 @@ function parseOptionsFromDsn(connString: string): ConnectionOptions {
     );
   }
 
+  let enforceTls = false;
+  if (dsn.params.sslmode) {
+    const sslmode = dsn.params.sslmode;
+    delete dsn.params.sslmode;
+
+    if (sslmode !== "require" && sslmode !== "allow") {
+      throw new ConnectionParamsError(
+        `Supplied DSN has invalid sslmode '${sslmode}'. Only 'require' or 'allow' are supported`,
+      );
+    }
+
+    if (sslmode === "require") {
+      enforceTls = true;
+    }
+  }
+
   return {
     ...dsn,
+    tls: { enforce: enforceTls },
     applicationName: dsn.params.application_name,
   };
 }

--- a/tests/connection_params_test.ts
+++ b/tests/connection_params_test.ts
@@ -139,7 +139,7 @@ test("dsnStyleParametersWithInvalidSSLMode", function () {
         "postgres://some_user@some_host:10101/deno_postgres?sslmode=disable",
       ),
     undefined,
-    "Supplied DSN has invalid sslmode 'disable'. Only 'require' or 'allow' are supported",
+    "Supplied DSN has invalid sslmode 'disable'. Only 'require' or 'prefer' are supported",
   );
 });
 

--- a/tests/connection_params_test.ts
+++ b/tests/connection_params_test.ts
@@ -102,6 +102,14 @@ test("dsnStyleParametersWithApplicationName", function () {
   assertEquals(p.port, 10101);
 });
 
+test("dsnStyleParametersWithSSLModeRequire", function () {
+  const p = createParams(
+    "postgres://some_user@some_host:10101/deno_postgres?sslmode=require",
+  );
+
+  assertEquals(p.tls.enforce, true);
+});
+
 test("dsnStyleParametersWithInvalidDriver", function () {
   assertThrows(
     () =>
@@ -121,6 +129,17 @@ test("dsnStyleParametersWithInvalidPort", function () {
       ),
     undefined,
     "Invalid URL",
+  );
+});
+
+test("dsnStyleParametersWithInvalidSSLMode", function () {
+  assertThrows(
+    () =>
+      createParams(
+        "postgres://some_user@some_host:10101/deno_postgres?sslmode=disable",
+      ),
+    undefined,
+    "Supplied DSN has invalid sslmode 'disable'. Only 'require' or 'allow' are supported",
   );
 });
 


### PR DESCRIPTION
libpq dsn support includes an `sslmode` flag to specify various levels of TLS requirement. This PR updates the DSN handling to allow `sslmode=prefer` (which seems to be the library's default) and `sslmode=require` to set `tls.enforce` on the connection.

@Soremwar I'm hoping in a near future PR to also get specifying a root cert set up as well and getting cert verification going as well, if you're cool with that.