### PR TITLE
refactor: Cleanup pool connection and add pool docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -120,11 +120,11 @@ For stronger management and scalability, you can use **pools**:
 ```ts
 const POOL_CONNECTIONS = 20;
 const dbPool = new Pool({
-  user: "user",
-  password: "password",
   database: "database",
   hostname: "hostname",
+  password: "password",
   port: 5432,
+  user: "user",
 }, POOL_CONNECTIONS);
 
 const client = await dbPool.connect(); // 19 connections are still available
@@ -132,14 +132,20 @@ await client.queryArray`UPDATE X SET Y = 'Z'`;
 await client.release(); // This connection is now available for use again
 ```
 
+The number of pools is up to you, but a pool of 20 is good for small
+applications, this can differ based on how active your application is. Increase
+or decrease where necessary.
+
 #### Clients vs connection pools
 
-Each pool creates as many connections as requested, allowing you to execute
-several queries concurrently. This also improves performance, as creating a
-whole new connection for each query can be an expensive operation, as would be
-the case if you were using **clients**.
+Each pool eagerly creates as many connections as requested, allowing you to
+execute several queries concurrently. This also improves performance, since
+creating a whole new connection for each query can be an expensive operation,
+making pools stand out from clients when dealing with concurrent, reusable
+connections.
 
 ```ts
+// Open 4 connections at once
 const pool = new Pool(db_params, 4);
 
 // This connections are already open, so there will be no overhead here
@@ -163,12 +169,12 @@ await client_4.connect();
 #### Lazy pools
 
 Another good option is to create such connections on demand and have them
-available after creation. So one of the active connections will be used instead
-of creating a new one. You can do this by indicating the pool to create each
-connection lazily.
+available after creation. That way, one of the available connections will be
+used instead of creating a new one. You can do this by indicating the pool to
+start each connection lazily.
 
 ```ts
-const pool = new Pool(db_params, 4, true); // True indicates lazy connections
+const pool = new Pool(db_params, 4, true); // `true` indicates lazy connections
 
 // A new connection is created when requested
 const client_1 = await pool.connect();
@@ -183,10 +189,6 @@ const client_3 = await pool.connect();
 await client_2.release();
 await client_3.release();
 ```
-
-The number of pools is up to you, but a pool of 20 is good for small
-applications, this can differ based on how active your application is. Increase
-or decrease where necessary.
 
 #### Pools made simple
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -117,10 +117,7 @@ await client.connect()
 
 For stronger management and scalability, you can use **pools**:
 
-```typescript
-import { Pool } from "https://deno.land/x/postgres/mod.ts";
-import { PoolClient } from "https://deno.land/x/postgres/client.ts";
-
+```ts
 const POOL_CONNECTIONS = 20;
 const dbPool = new Pool({
   user: "user",
@@ -130,25 +127,84 @@ const dbPool = new Pool({
   port: 5432,
 }, POOL_CONNECTIONS);
 
-async function runQuery(query: string) {
-  const client: PoolClient = await dbPool.connect();
-  const dbResult = await client.queryObject(query);
-  client.release();
-  return dbResult;
-}
-
-await runQuery("SELECT ID, NAME FROM users;"); // [{id: 1, name: 'Carlos'}, {id: 2, name: 'John'}, ...]
-await runQuery("SELECT ID, NAME FROM users WHERE id = '1';"); // [{id: 1, name: 'Carlos'}, {id: 2, name: 'John'}, ...]
+const client = await dbPool.connect(); // 19 connections are still available
+await client.queryArray`UPDATE X SET Y = 'Z'`;
+await client.release(); // This connection is now available for use again
 ```
 
-This improves performance, as creating a whole new connection for each query can
-be an expensive operation. With pools, you can keep the connections open to be
-re-used when requested using the `connect()` method. So one of the active
-connections will be used instead of creating a new one.
+#### Clients vs connection pools
+
+Each pool creates as many connections as requested, allowing you to execute
+several queries concurrently. This also improves performance, as creating a
+whole new connection for each query can be an expensive operation, as would be
+the case if you were using **clients**.
+
+```ts
+const pool = new Pool(db_params, 4);
+
+// This connections are already open, so there will be no overhead here
+const pool_client_1 = await pool.connect();
+const pool_client_2 = await pool.connect();
+const pool_client_3 = await pool.connect();
+const pool_client_4 = await pool.connect();
+
+// Each one of these will have to open a new connection and they won't be
+// reusable after the client is closed
+const client_1 = new Client(db_params);
+await client_1.connect();
+const client_2 = new Client(db_params);
+await client_2.connect();
+const client_3 = new Client(db_params);
+await client_3.connect();
+const client_4 = new Client(db_params);
+await client_4.connect();
+```
+
+#### Lazy pools
+
+Another good option is to create such connections on demand and have them
+available after creation. So one of the active connections will be used instead
+of creating a new one. You can do this by indicating the pool to create each
+connection lazily.
+
+```ts
+const pool = new Pool(db_params, 4, true); // True indicates lazy connections
+
+// A new connection is created when requested
+const client_1 = await pool.connect();
+client_1.release();
+
+// No new connection is created, previously initialized one is available
+const client_2 = await pool.connect();
+
+// A new connection is created because all the other ones are in use
+const client_3 = await pool.connect();
+
+await client_2.release();
+await client_3.release();
+```
 
 The number of pools is up to you, but a pool of 20 is good for small
 applications, this can differ based on how active your application is. Increase
 or decrease where necessary.
+
+#### Pools made simple
+
+The following example is a simple abstraction over pools that allow you to
+execute one query and release the used client after returning the result in a
+single function call
+
+```ts
+async function runQuery(query: string) {
+  const client = await pool.connect();
+  const result = await client.queryObject(query);
+  client.release();
+  return result;
+}
+
+await runQuery("SELECT ID, NAME FROM users"); // [{id: 1, name: 'Carlos'}, {id: 2, name: 'John'}, ...]
+await runQuery("SELECT ID, NAME FROM users WHERE id = '1'"); // [{id: 1, name: 'Carlos'}, {id: 2, name: 'John'}, ...]
+```
 
 ## API
 

--- a/pool.ts
+++ b/pool.ts
@@ -8,8 +8,56 @@ import {
 } from "./connection/connection_params.ts";
 import { DeferredStack } from "./connection/deferred.ts";
 
+/**
+ * Connection pools are a powerful resource to execute parallel queries and
+ * to save up time in connection initialization. It is highly recommended that all
+ * applications that require concurrent access use a connection pool to stablish
+ * connection with their PostgreSQL database
+ * 
+ * ```ts
+ * const pool = new Pool({
+ *   database: "database",
+ *   hostname: "hostname",
+ *   password: "password",
+ *   port: 5432,
+ *   user: "user",
+ * }, 10); // Creates a pool with 10 available connections
+ * 
+ * const client = await pool.connect();
+ * await client.queryArray`SELECT 1`;
+ * await client.release();
+ * ```
+ * 
+ * You can also opt to not initialize all your connections at once by passing the `lazy`
+ * option when instantiating your pool, this is useful to reduce startup time. In
+ * addition to this, the pool won't start the connection unless there isn't any already
+ * available connections in the Pool
+ * 
+ * ```ts
+ * // Creates a pool with 10 available connections
+ * // Connection with the database won't be established until the user requires it
+ * const pool = new Pool(connection_params, 10, false);
+ * 
+ * // Connection is created here, will be available from now on
+ * const client_1 = await pool.connect();
+ * await client_1.queryArray`SELECT 1`;
+ * await client_1.release();
+ * 
+ * // Same connection as before, will be reused instead of starting a new one
+ * const client_2 = await pool.connect();
+ * await client_2.queryArray`SELECT 1`;
+ * 
+ * // New connection, since previous one is still in use
+ * // There will be two open connections available from now on
+ * const client_3 = await pool.connect();
+ * await client_2.release();
+ * await client_3.release();
+ * ```
+ */
 export class Pool {
   #available_connections: DeferredStack<Connection> | null = null;
+  #connection_params: ConnectionParams;
+  #ended = false;
   #lazy: boolean;
   #max_size: number;
   // TODO
@@ -21,14 +69,19 @@ export class Pool {
     connection_params: ConnectionOptions | ConnectionString | undefined,
     // deno-lint-ignore camelcase
     max_size: number,
-    lazy?: boolean,
+    lazy: boolean = false,
   ) {
+    this.#connection_params = createParams(connection_params);
+    this.#lazy = lazy;
     this.#max_size = max_size;
-    this.#lazy = !!lazy;
-    this.#ready = this.#initialize(createParams(connection_params));
+    this.#ready = this.#initialize();
   }
 
-  /** number of available connections */
+  /**
+   * The number of open connections available for use
+   * 
+   * Lazy initialized pools won't have any open connections by default
+   */
   get available(): number {
     if (this.#available_connections == null) {
       return 0;
@@ -36,42 +89,92 @@ export class Pool {
     return this.#available_connections.available;
   }
 
+  /**
+   * This will return a new client from the available connections in
+   * the pool
+   * 
+   * In the case of lazy initialized pools, a new connection will be established
+   * with the database if no other connections are available
+   * 
+   * ```ts
+   * const client = pool.connect();
+   * await client.queryArray`UPDATE MY_TABLE SET X = 1`;
+   * await client.release();
+   * ```
+   */
   async connect(): Promise<PoolClient> {
+    // Reinitialize pool if it has been terminated
+    if (this.#ended) {
+      this.#ready = this.#initialize();
+    }
+
     await this.#ready;
     const connection = await this.#available_connections!.pop();
     const release = () => this.#available_connections!.push(connection);
     return new PoolClient(connection, release);
   }
 
-  #createConnection = async (params: ConnectionParams): Promise<Connection> => {
-    const connection = new Connection(params);
+  #createConnection = async (): Promise<Connection> => {
+    const connection = new Connection(this.#connection_params);
     await connection.startup();
     return connection;
   };
 
+  /**
+   * This will close all open connections and set a terminated status in the pool
+   * 
+   * ```ts
+   * await pool.end();
+   * assertEquals(pool.available, 0);
+   * await pool.end(); // An exception will be thrown, pool doesn't have any connections to close
+   * ```
+   * 
+   * However, a terminated pool can be reused by using the "connect" method, which
+   * will reinitialize the connections according to the original configuration of the pool
+   * 
+   * ```ts
+   * await pool.end();
+   * const client = await pool.connect();
+   * await client.queryArray`SELECT 1`; // Works!
+   * await client.close();
+   * ```
+   */
   async end(): Promise<void> {
+    if (this.#ended) {
+      throw new Error("Pool connections have already been terminated");
+    }
+
     await this.#ready;
     while (this.available > 0) {
       const conn = await this.#available_connections!.pop();
       await conn.end();
     }
+
+    this.#available_connections = null;
+    this.#ended = true;
   }
 
-  #initialize = async (params: ConnectionParams): Promise<void> => {
+  #initialize = async (): Promise<void> => {
     const initSize = this.#lazy ? 1 : this.#max_size;
     const connections = Array.from(
       { length: initSize },
-      () => this.#createConnection(params),
+      () => this.#createConnection(),
     );
 
     this.#available_connections = new DeferredStack(
       this.#max_size,
       await Promise.all(connections),
-      this.#createConnection.bind(this, params),
+      this.#createConnection.bind(this),
     );
+
+    this.#ended = false;
   };
 
-  /** number of connections created */
+  /**
+   * The number of total connections open in the pool
+   * 
+   * Both available and in use connections will be counted
+   */
   get size(): number {
     if (this.#available_connections == null) {
       return 0;

--- a/pool.ts
+++ b/pool.ts
@@ -1,4 +1,4 @@
-import { PoolClient, QueryClient } from "./client.ts";
+import { PoolClient } from "./client.ts";
 import { Connection } from "./connection/connection.ts";
 import {
   ConnectionOptions,
@@ -7,44 +7,68 @@ import {
   createParams,
 } from "./connection/connection_params.ts";
 import { DeferredStack } from "./connection/deferred.ts";
-import {
-  Query,
-  QueryArrayResult,
-  QueryObjectResult,
-  QueryResult,
-  ResultType,
-} from "./query/query.ts";
 
 // TODO
 // Remove query execution methods from main pool
 export class Pool {
-  #connectionParams: ConnectionParams;
-  // TODO
-  // Cleanup initialization
-  #connections!: Array<Connection>;
-  #availableConnections!: DeferredStack<Connection>;
+  #availableConnections: DeferredStack<Connection> | null = null;
+  #lazy: boolean;
   #maxSize: number;
   // TODO
-  // Initialization should probably have a startup
-  public ready: Promise<void>;
-  #lazy: boolean;
+  // Initialization should probably have a timeout
+  #ready: Promise<void>;
 
   constructor(
     connectionParams: ConnectionOptions | ConnectionString | undefined,
     maxSize: number,
     lazy?: boolean,
   ) {
-    this.#connectionParams = createParams(connectionParams);
     this.#maxSize = maxSize;
     this.#lazy = !!lazy;
-    this.ready = this.#startup();
+    this.#ready = this.#initialize(createParams(connectionParams));
   }
 
-  private async _createConnection(): Promise<Connection> {
-    const connection = new Connection(this.#connectionParams);
+  /** number of available connections */
+  get available(): number {
+    if (this.#availableConnections == null) {
+      return 0;
+    }
+    return this.#availableConnections.available;
+  }
+
+  async connect(): Promise<PoolClient> {
+    await this.#ready;
+    const connection = await this.#availableConnections!.pop();
+    const release = () => this.#availableConnections!.push(connection);
+    return new PoolClient(connection, release);
+  }
+
+  #createConnection = async (params: ConnectionParams): Promise<Connection> => {
+    const connection = new Connection(params);
     await connection.startup();
     return connection;
+  };
+
+  async end(): Promise<void> {
+    await this.#ready;
+    while (this.available > 0) {
+      const conn = await this.#availableConnections!.pop();
+      await conn.end();
+    }
   }
+
+  #initialize = async (params: ConnectionParams): Promise<void> => {
+    const initSize = this.#lazy ? 1 : this.#maxSize;
+    const connections = [...Array(initSize)].map(() =>
+      this.#createConnection(params)
+    );
+
+    this.#availableConnections = new DeferredStack(
+      this.#maxSize,
+      await Promise.all(connections),
+      this.#createConnection.bind(this, params),
+    );
+  };
 
   /** pool max size */
   get maxSize(): number {
@@ -57,41 +81,5 @@ export class Pool {
       return 0;
     }
     return this.#availableConnections.size;
-  }
-
-  /** number of available connections */
-  get available(): number {
-    if (this.#availableConnections == null) {
-      return 0;
-    }
-    return this.#availableConnections.available;
-  }
-
-  #startup = async (): Promise<void> => {
-    const initSize = this.#lazy ? 1 : this.#maxSize;
-    const connecting = [...Array(initSize)].map(async () =>
-      await this._createConnection()
-    );
-    this.#connections = await Promise.all(connecting);
-    this.#availableConnections = new DeferredStack(
-      this.#maxSize,
-      this.#connections,
-      this._createConnection.bind(this),
-    );
-  };
-
-  async connect(): Promise<PoolClient> {
-    await this.ready;
-    const connection = await this.#availableConnections.pop();
-    const release = () => this.#availableConnections.push(connection);
-    return new PoolClient(connection, release);
-  }
-
-  async end(): Promise<void> {
-    await this.ready;
-    while (this.available > 0) {
-      const conn = await this.#availableConnections.pop();
-      await conn.end();
-    }
   }
 }

--- a/pool.ts
+++ b/pool.ts
@@ -31,11 +31,10 @@ import { DeferredStack } from "./connection/deferred.ts";
  * You can also opt to not initialize all your connections at once by passing the `lazy`
  * option when instantiating your pool, this is useful to reduce startup time. In
  * addition to this, the pool won't start the connection unless there isn't any already
- * available connections in the Pool
+ * available connections in the pool
  * 
  * ```ts
  * // Creates a pool with 10 max available connections
- * // No connections are started until requested
  * // Connection with the database won't be established until the user requires it
  * const pool = new Pool(connection_params, 10, true);
  * 

--- a/pool.ts
+++ b/pool.ts
@@ -10,9 +10,9 @@ import { DeferredStack } from "./connection/deferred.ts";
 
 /**
  * Connection pools are a powerful resource to execute parallel queries and
- * to save up time in connection initialization. It is highly recommended that all
- * applications that require concurrent access use a connection pool to stablish
- * connection with their PostgreSQL database
+ * save up time in connection initialization. It is highly recommended that all
+ * applications that require concurrent access use a pool to communicate
+ * with their PostgreSQL database
  * 
  * ```ts
  * const pool = new Pool({
@@ -34,9 +34,10 @@ import { DeferredStack } from "./connection/deferred.ts";
  * available connections in the Pool
  * 
  * ```ts
- * // Creates a pool with 10 available connections
+ * // Creates a pool with 10 max available connections
+ * // No connections are started until requested
  * // Connection with the database won't be established until the user requires it
- * const pool = new Pool(connection_params, 10, false);
+ * const pool = new Pool(connection_params, 10, true);
  * 
  * // Connection is created here, will be available from now on
  * const client_1 = await pool.connect();
@@ -80,7 +81,7 @@ export class Pool {
   /**
    * The number of open connections available for use
    * 
-   * Lazy initialized pools won't have any open connections by default
+   * Lazily initialized pools won't have any open connections by default
    */
   get available(): number {
     if (this.#available_connections == null) {
@@ -155,7 +156,7 @@ export class Pool {
   }
 
   #initialize = async (): Promise<void> => {
-    const initSize = this.#lazy ? 1 : this.#max_size;
+    const initSize = this.#lazy ? 0 : this.#max_size;
     const connections = Array.from(
       { length: initSize },
       () => this.#createConnection(),

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -170,6 +170,26 @@ testPool(async function manyQueries(POOL) {
   assertEquals(result, expected);
 });
 
+testPool(async function reconnectAfterPoolEnd(POOL) {
+  await POOL.end();
+  assertEquals(POOL.available, 0);
+
+  const client = await POOL.connect();
+  await client.queryArray`SELECT 1`;
+  await client.release();
+  assertEquals(POOL.available, 10);
+});
+
+testPool(async function reconnectAfterLazyPoolEnd(POOL) {
+  await POOL.end();
+  assertEquals(POOL.available, 0);
+
+  const client = await POOL.connect();
+  await client.queryArray`SELECT 1`;
+  await client.release();
+  assertEquals(POOL.available, 1);
+}, true);
+
 testPool(async function transaction(POOL) {
   const client = await POOL.connect();
   // deno-lint-ignore camelcase


### PR DESCRIPTION
- This allows users to reinitialize a pool connection after it as been closed
- This changes pool behavior by not initiating any connection before a client is requested, previous behavior opened one connection in advance