### PR TITLE
fixed Deno.conn

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,19 @@ Deno.test("INSERT works correctly", async () => {
 });
 ```
 
+## Deno compatibility
+
+Due to a not intended breaking change in Deno 1.9.0, two versions of
+`deno-postgres` require a specific version of Deno in order to work correctly,
+the following is a compatibility table that ranges from Deno 1.8 to Deno 1.9 and
+above indicating possible compatibility problems
+
+| Deno version | Min driver version | Max driver version |
+| ------------ | ------------------ | ------------------ |
+| 1.8.x        | 0.5.0              | 0.10.0             |
+| 1.9.0        | 0.11.0             | 0.11.1             |
+| 1.9.1 and up | 0.11.2             |                    |
+
 ## Contributing guidelines
 
 When contributing to repository make sure to:

--- a/connection/connection.ts
+++ b/connection/connection.ts
@@ -146,7 +146,7 @@ const encoder = new TextEncoder();
 export class Connection {
   #bufReader!: BufReader;
   #bufWriter!: BufWriter;
-  #conn!: Deno.Conn<Deno.NetAddr>;
+  #conn!: Deno.Conn;
   connected = false;
   #packetWriter = new PacketWriter();
   // TODO


### PR DESCRIPTION
This PR should close #281 as it removes the generic from Deno.Conn. I am not sure which implications it has by changing this, but from the tests, it seems like everything still works as intended.