### PR TITLE
chore: Setup testing on host machine

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,23 @@ Deno.test("INSERT works correctly", async () => {
 });
 ```
 
+### Setting up an advanced development environment
+
+More advanced features such as the Deno inspector, test filtering, database
+inspection and permission filtering can be achieved by setting up a local
+testing environment, as shown in the following steps:
+
+1. Start the development databases using the Docker service with the command\
+   `docker-compose up postgres postgres_scram postgres_invalid_tls`\
+   Though using the detach (`-d`) option is recommended, this will make the
+   databases run in the background unless you use docker itself to stop them.
+   You can find more info about this
+   [here](https://docs.docker.com/compose/reference/up)
+2. Run the tests manually by using the command\
+   `DEVELOPMENT=true deno test --unstable -A`\
+   The `DEVELOPMENT` variable will tell the testing pipeline to use the local
+   testing settings specified in `tests/config.json`
+
 ## Deno compatibility
 
 Due to a not intended breaking change in Deno 1.9.0, two versions of

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     volumes:
       - ./docker/postgres/data/:/var/lib/postgresql/host/
       - ./docker/postgres/init/:/docker-entrypoint-initdb.d/
+    ports:
+      - "6001:5432"
   postgres_scram:
     image: postgres
     hostname: postgres_scram
@@ -23,6 +25,8 @@ services:
     volumes:
       - ./docker/postgres_scram/data/:/var/lib/postgresql/host/
       - ./docker/postgres_scram/init/:/docker-entrypoint-initdb.d/
+    ports:
+      - "6002:5432"
   postgres_invalid_tls:
     image: postgres
     hostname: postgres_invalid_tls
@@ -33,6 +37,8 @@ services:
     volumes:
       - ./docker/postgres_invalid_tls/data/:/var/lib/postgresql/host/
       - ./docker/postgres_invalid_tls/init/:/docker-entrypoint-initdb.d/
+    ports:
+      - "6003:5432"
   tests:
     build: .
     depends_on:

--- a/tests/config.json
+++ b/tests/config.json
@@ -1,37 +1,76 @@
 {
-  "postgres": {
-    "applicationName": "deno_postgres",
-    "database": "postgres",
-    "hostname": "postgres",
-    "password": "postgres",
-    "port": 5432,
-    "users": {
-      "clear": "clear",
-      "main": "postgres",
-      "md5": "md5"
-    }
-  },
-  "postgres_scram": {
-    "applicationName": "deno_postgres",
-    "database": "postgres",
-    "hostname": "postgres_scram",
-    "password": "postgres",
-    "port": 5432,
-    "users": {
-      "scram": "scram"
-    }
-  },
-  "postgres_invalid_tls": {
-    "applicationName": "deno_postgres",
-    "database": "postgres",
-    "hostname": "postgres_invalid_tls",
-    "password": "postgres",
-    "port": 5432,
-    "tls": {
-      "enforce": true
+  "ci": {
+    "postgres": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "postgres",
+      "password": "postgres",
+      "port": 5432,
+      "users": {
+        "clear": "clear",
+        "main": "postgres",
+        "md5": "md5"
+      }
     },
-    "users": {
-      "main": "postgres"
+    "postgres_scram": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "postgres_scram",
+      "password": "postgres",
+      "port": 5432,
+      "users": {
+        "scram": "scram"
+      }
+    },
+    "postgres_invalid_tls": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "postgres_invalid_tls",
+      "password": "postgres",
+      "port": 5432,
+      "tls": {
+        "enforce": true
+      },
+      "users": {
+        "main": "postgres"
+      }
+    }
+  },
+  "local": {
+    "postgres": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "localhost",
+      "password": "postgres",
+      "port": 6001,
+      "users": {
+        "clear": "clear",
+        "main": "postgres",
+        "md5": "md5"
+      }
+    },
+    "postgres_scram": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "localhost",
+      "password": "postgres",
+      "port": 6002,
+      "users": {
+        "scram": "scram"
+      }
+    },
+    "postgres_invalid_tls": {
+      "applicationName": "deno_postgres",
+      "database": "postgres",
+      "hostname": "localhost",
+      "password": "postgres",
+      "port": 6003,
+      "tls": {
+        "enforce": true
+      },
+      "users": {
+        "main": "postgres"
+      }
     }
   }
 }


### PR DESCRIPTION
This PR adds an option to run the tests on the developer machine, allowing the possibility of using the inspector while testing the application