### PR TITLE
Fix threshold for applying 0 padding when encoding hex

### DIFF
--- a/query/encode.ts
+++ b/query/encode.ts
@@ -74,7 +74,7 @@ function encodeArray(array: Array<unknown>): string {
 
 function encodeBytes(value: Uint8Array): string {
   const hex = Array.from(value)
-    .map((val) => (val < 10 ? `0${val.toString(16)}` : val.toString(16)))
+    .map((val) => (val < 0x10 ? `0${val.toString(16)}` : val.toString(16)))
     .join("");
   return `\\x${hex}`;
 }

--- a/tests/encode_test.ts
+++ b/tests/encode_test.ts
@@ -67,7 +67,7 @@ test("encodeUint8Array", function () {
   const buf2 = new Uint8Array([2, 10, 500]);
 
   assertEquals("\\x010203", encode(buf1));
-  assertEquals("\\x02af4", encode(buf2));
+  assertEquals("\\x020af4", encode(buf2));
 });
 
 test("encodeArray", function () {

--- a/tests/encode_test.ts
+++ b/tests/encode_test.ts
@@ -65,9 +65,11 @@ test("encodeObject", function () {
 test("encodeUint8Array", function () {
   const buf1 = new Uint8Array([1, 2, 3]);
   const buf2 = new Uint8Array([2, 10, 500]);
+  const buf3 = new Uint8Array([11]);
 
   assertEquals("\\x010203", encode(buf1));
   assertEquals("\\x020af4", encode(buf2));
+  assertEquals("\\x0b", encode(buf3));
 });
 
 test("encodeArray", function () {


### PR DESCRIPTION
```diff
-val < 10 ? `0${val.toString(16)}` : val.toString(16))
+val < 0x10 ? `0${val.toString(16)}` : val.toString(16))
```

E.g. when `val` is 11 it should encode as `"0b"` but 11 is not less than 10 so it doesn't get padded.

This surfaces from postgres as
`PostgresError: invalid hexadecimal data: odd number of digits`
when trying to use `bytea`.