### PR TITLE
feat: Option to automatically turn snake_case columns in a query response into camelCase fields #310

### DIFF
--- a/query/query.ts
+++ b/query/query.ts
@@ -206,10 +206,11 @@ export class QueryObjectResult<
       (row: Record<string, unknown>, raw_value, index) => {
         const column = this.rowDescription!.columns[index];
 
-
         // convert snake_case to camelCase
-        if (snakeToCamel) const name = this.snakeToCamelCase(this.query.fields?.[index] ?? column.name);
-          else const name = this.query.fields?.[index] ?? column.name;
+        const snakeToCamel: boolean = true;
+        let name;
+        if (snakeToCamel) name = this.snakeToCamelCase(this.query.fields?.[index] ?? column.name);
+        else name = this.query.fields?.[index] ?? column.name;
 
         // Find the field name provided by the user
         // default to database provided name

--- a/query/query.ts
+++ b/query/query.ts
@@ -165,6 +165,19 @@ export class QueryObjectResult<
 > extends QueryResult {
   public rows: T[] = [];
 
+  private snakeToCamelCase = (input: string) =>
+  input
+    .split("_")
+    .reduce(
+      (res, word, i) =>
+        i === 0
+          ? word.toLowerCase()
+          : `${res}${word.charAt(0).toUpperCase()}${word
+              .substr(1)
+              .toLowerCase()}`,
+      ""
+    );
+
   insertRow(row_data: Uint8Array[]) {
     if (this._done) {
       throw new Error(
@@ -193,10 +206,13 @@ export class QueryObjectResult<
       (row: Record<string, unknown>, raw_value, index) => {
         const column = this.rowDescription!.columns[index];
 
+
+        // convert snake_case to camelCase
+        if (snakeToCamel) const name = this.snakeToCamelCase(this.query.fields?.[index] ?? column.name);
+          else const name = this.query.fields?.[index] ?? column.name;
+
         // Find the field name provided by the user
         // default to database provided name
-        const name = this.query.fields?.[index] ?? column.name;
-
         if (raw_value === null) {
           row[name] = null;
         } else {

--- a/query/query.ts
+++ b/query/query.ts
@@ -49,6 +49,7 @@ export interface QueryConfig {
   encoder?: (arg: unknown) => EncodedArg;
   name?: string;
   text: string;
+  snakeToCamel?: boolean;
 }
 
 export interface QueryObjectConfig extends QueryConfig {
@@ -234,7 +235,7 @@ export class Query<T extends ResultType> {
   public fields?: string[];
   public result_type: ResultType;
   public text: string;
-
+  public snakeToCamel?: boolean;
   constructor(config: QueryObjectConfig, result_type: T);
   constructor(text: string, result_type: T, ...args: unknown[]);
   constructor(
@@ -278,6 +279,11 @@ export class Query<T extends ResultType> {
     }
     this.text = config.text;
     this.args = this.#prepareArgs(config);
+
+    this.snakeToCamel = config.snakeToCamel;
+    if (this.snakeToCamel===undefined) {
+      this.snakeToCamel = false;            // default = do not convert to CamelCase
+    }
   }
 
   #prepareArgs(config: QueryConfig): EncodedArg[] {


### PR DESCRIPTION
I've been using this feature and it works well (see the proposed changes). I didn't implement the switch as it should be compliant with the vision of the authors, so please advise where to put the switch and how to name it ?
I'm addressing "query.ts -> snakeToCamel" in particular !

Best