### PR TITLE
feat: use caCertificates instead of caFile

### DIFF
--- a/connection/connection.ts
+++ b/connection/connection.ts
@@ -227,7 +227,7 @@ export class Connection {
 
   async #createTlsConnection(
     connection: Deno.Conn,
-    options: { hostname: string; certFile?: string },
+    options: { hostname: string; caCerts: string[] },
   ) {
     if ("startTls" in Deno) {
       // @ts-ignore This API should be available on unstable
@@ -272,7 +272,7 @@ export class Connection {
       tls: {
         enabled: tls_enabled,
         enforce: tls_enforced,
-        caFile,
+        caCertificates,
       },
     } = this.#connection_params;
 
@@ -294,7 +294,7 @@ export class Connection {
         try {
           await this.#createTlsConnection(this.#conn, {
             hostname,
-            certFile: caFile,
+            caCerts: caCertificates,
           });
           this.#tls = true;
         } catch (e) {

--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -47,19 +47,26 @@ export interface TLSOptions {
   /**
    * If TLS support is enabled or not. If the server requires TLS,
    * the connection will fail.
+   *
+   * Default: `true`
    */
   enabled: boolean;
   /**
    * This will force the connection to run over TLS
    * If the server doesn't support TLS, the connection will fail
    *
-   * default: `false`
+   * Default: `false`
    */
   enforce: boolean;
   /**
-   * A custom CA file to use for the TLS connection to the server.
+   * A list of root certificates that will be used in addition to the default
+   * root certificates to verify the server's certificate.
+   *
+   * Must be in PEM format.
+   *
+   * Default: `[]`
    */
-  caFile?: string;
+  caCertificates: string[];
 }
 
 export interface ClientOptions {
@@ -135,7 +142,7 @@ function parseOptionsFromDsn(connString: string): ClientOptions {
     );
   }
 
-  let tls: TLSOptions = { enabled: true, enforce: false };
+  let tls: TLSOptions = { enabled: true, enforce: false, caCertificates: [] };
   if (dsn.params.sslmode) {
     const sslmode = dsn.params.sslmode;
     delete dsn.params.sslmode;
@@ -147,11 +154,11 @@ function parseOptionsFromDsn(connString: string): ClientOptions {
     }
 
     if (sslmode === "require") {
-      tls = { enabled: true, enforce: true };
+      tls = { enabled: true, enforce: true, caCertificates: [] };
     }
 
     if (sslmode === "disable") {
-      tls = { enabled: false, enforce: false };
+      tls = { enabled: false, enforce: false, caCertificates: [] };
     }
   }
 
@@ -172,6 +179,7 @@ const DEFAULT_OPTIONS: Omit<ClientConfiguration, "database" | "user"> = {
   tls: {
     enabled: true,
     enforce: false,
+    caCertificates: [],
   },
 };
 
@@ -233,7 +241,7 @@ export function createParams(
     tls: {
       enabled: tls_enabled,
       enforce: tls_enforced,
-      caFile: params?.tls?.caFile,
+      caCertificates: params?.tls?.caCertificates ?? [],
     },
     user: params.user ?? pgEnv.user,
   };

--- a/docs/README.md
+++ b/docs/README.md
@@ -199,10 +199,10 @@ There is a miriad of factors you have to take into account when using a
 certificate to encrypt your connection that, if not taken care of, can render
 your certificate invalid.
 
-When using a self signed certificate, make sure to specify the path to the CA
-certificate in the `tls.caFile` option when creating the Postgres `Client`, or
-using the `--cert` option when starting Deno. The latter approach only works for
-Deno 1.12.2 or later.
+When using a self signed certificate, make sure to specify the PEM encoded CA
+certificate in the `tls.caCertificates` option when creating the Postgres
+`Client` (Deno 1.15.0 later), or using the `--cert` option when starting Deno
+(Deno 1.12.2 or later).
 
 TLS can be disabled from your server by editing your `postgresql.conf` file and
 setting the `ssl` option to `off`, or in the driver side by using the "disabled"

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -38,7 +38,11 @@ const config = Deno.env.get("DENO_POSTGRES_DEVELOPMENT") === "true"
   : config_file.ci;
 
 const enabled_tls = {
-  caFile: fromFileUrl(new URL("../docker/certs/ca.crt", import.meta.url)),
+  caCertificates: [
+    Deno.readTextFileSync(
+      new URL("../docker/certs/ca.crt", import.meta.url),
+    ),
+  ],
   enabled: true,
   enforce: true,
 };


### PR DESCRIPTION
In Deno 1.15 CA files can be specified as PEM encoded cert
strings, rather than as file paths to the PEM encoded certs.

See https://github.com/denoland/deno/commit/0d7a417f332a57fb3e89250a1ce250b929d0b2f7

Dependant on #345.