### PR TITLE
chore: fixed typo required -> require

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -60,7 +60,7 @@ config = {
 
 // Alternatively you can use a connection string
 config =
-  "postgres://user:password@localhost:5432/test?application_name=my_custom_app&sslmode=required";
+  "postgres://user:password@localhost:5432/test?application_name=my_custom_app&sslmode=require";
 
 const client = new Client(config);
 await client.connect();


### PR DESCRIPTION
only fixed typo required -> require  
> Only 'disable', 'require', and 'prefer' are supported
https://github.com/denodrivers/postgres/blob/160608b0617e6dc3dae156a90f099f4022a1a081/connection/connection_params.ts#L145