### PR TITLE
fix: Parse date string correctly

### DIFF
--- a/deps.ts
+++ b/deps.ts
@@ -1,3 +1,5 @@
+export * as base64 from "https://deno.land/std@0.113.0/encoding/base64.ts";
+export * as date from "https://deno.land/std@0.113.0/datetime/mod.ts";
 export {
   BufReader,
   BufWriter,
@@ -5,7 +7,6 @@ export {
 export { copy } from "https://deno.land/std@0.113.0/bytes/mod.ts";
 export { createHash } from "https://deno.land/std@0.113.0/hash/mod.ts";
 export { HmacSha256 } from "https://deno.land/std@0.113.0/hash/sha256.ts";
-export * as base64 from "https://deno.land/std@0.113.0/encoding/base64.ts";
 export { deferred, delay } from "https://deno.land/std@0.113.0/async/mod.ts";
 export type { Deferred } from "https://deno.land/std@0.113.0/async/mod.ts";
 export { bold, yellow } from "https://deno.land/std@0.113.0/fmt/colors.ts";

--- a/query/decoders.ts
+++ b/query/decoders.ts
@@ -1,3 +1,4 @@
+import { date } from "../deps.ts";
 import { parseArray } from "./array_parser.ts";
 import {
   Box,
@@ -16,7 +17,6 @@ import {
 // Copyright (c) Ben Drucker <bvdrucker@gmail.com> (bendrucker.me). MIT License.
 const BACKSLASH_BYTE_VALUE = 92;
 const BC_RE = /BC$/;
-const DATE_RE = /^(\d{1,})-(\d{2})-(\d{2})$/;
 const DATETIME_RE =
   /^(\d{1,})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?/;
 const HEX = 16;
@@ -127,23 +127,7 @@ export function decodeDate(dateStr: string): Date | number {
     return Number(-Infinity);
   }
 
-  const matches = DATE_RE.exec(dateStr);
-
-  if (!matches) {
-    throw new Error(`"${dateStr}" could not be parsed to date`);
-  }
-
-  const year = parseInt(matches[1], 10);
-  // remember JS dates are 0-based
-  const month = parseInt(matches[2], 10) - 1;
-  const day = parseInt(matches[3], 10);
-  const date = new Date(year, month, day);
-  // use `setUTCFullYear` because if date is from first
-  // century `Date`'s compatibility for millenium bug
-  // would set it as 19XX
-  date.setUTCFullYear(year);
-
-  return date;
+  return date.parse(dateStr, "yyyy-MM-dd");
 }
 
 export function decodeDateArray(value: string) {

--- a/tests/data_types_test.ts
+++ b/tests/data_types_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, base64, formatDate, parseDate } from "./test_deps.ts";
+import { assertEquals, base64, date } from "./test_deps.ts";
 import { getMainConfiguration } from "./config.ts";
 import { generateSimpleClientTest } from "./helpers.ts";
 import {
@@ -923,7 +923,7 @@ Deno.test(
 Deno.test(
   "date",
   testClient(async (client) => {
-    await client.queryArray`SET SESSION TIMEZONE TO '${timezone}'`;
+    await client.queryArray(`SET SESSION TIMEZONE TO '${timezone}'`);
     const date_text = "2020-01-01";
 
     const result = await client.queryArray<[Timestamp, Timestamp]>(
@@ -932,7 +932,7 @@ Deno.test(
     );
 
     assertEquals(result.rows[0], [
-      parseDate(date_text, "yyyy-MM-dd"),
+      date.parse(date_text, "yyyy-MM-dd"),
       Infinity,
     ]);
   }),
@@ -941,8 +941,8 @@ Deno.test(
 Deno.test(
   "date array",
   testClient(async (client) => {
-    await client.queryArray`SET SESSION TIMEZONE TO '${timezone}'`;
-    const dates = ["2020-01-01", formatDate(new Date(), "yyyy-MM-dd")];
+    await client.queryArray(`SET SESSION TIMEZONE TO '${timezone}'`);
+    const dates = ["2020-01-01", date.format(new Date(), "yyyy-MM-dd")];
 
     const result = await client.queryArray<[Timestamp, Timestamp]>(
       "SELECT ARRAY[$1::DATE, $2]",
@@ -951,7 +951,7 @@ Deno.test(
 
     assertEquals(
       result.rows[0][0],
-      dates.map((date) => parseDate(date, "yyyy-MM-dd")),
+      dates.map((d) => date.parse(d, "yyyy-MM-dd")),
     );
   }),
 );

--- a/tests/data_types_test.ts
+++ b/tests/data_types_test.ts
@@ -42,7 +42,8 @@ function randomBase64(): string {
   );
 }
 
-const timezone = new Date().toTimeString().slice(12, 17);
+const timezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
+const timezone_utc = new Date().toTimeString().slice(12, 17);
 
 const testClient = generateSimpleClientTest(getMainConfiguration());
 
@@ -813,7 +814,7 @@ Deno.test(
   "timetz",
   testClient(async (client) => {
     const result = await client.queryArray<[string]>(
-      `SELECT '01:01:01${timezone}'::TIMETZ`,
+      `SELECT '01:01:01${timezone_utc}'::TIMETZ`,
     );
 
     assertEquals(result.rows[0][0].slice(0, 8), "01:01:01");
@@ -824,7 +825,7 @@ Deno.test(
   "timetz array",
   testClient(async (client) => {
     const result = await client.queryArray<[string]>(
-      `SELECT ARRAY['01:01:01${timezone}'::TIMETZ]`,
+      `SELECT ARRAY['01:01:01${timezone_utc}'::TIMETZ]`,
     );
 
     assertEquals(typeof result.rows[0][0][0], "string");
@@ -922,6 +923,7 @@ Deno.test(
 Deno.test(
   "date",
   testClient(async (client) => {
+    await client.queryArray`SET SESSION TIMEZONE TO '${timezone}'`;
     const date_text = "2020-01-01";
 
     const result = await client.queryArray<[Timestamp, Timestamp]>(
@@ -939,6 +941,7 @@ Deno.test(
 Deno.test(
   "date array",
   testClient(async (client) => {
+    await client.queryArray`SET SESSION TIMEZONE TO '${timezone}'`;
     const dates = ["2020-01-01", formatDate(new Date(), "yyyy-MM-dd")];
 
     const result = await client.queryArray<[Timestamp, Timestamp]>(

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -7,8 +7,4 @@ export {
   assertThrows,
   assertThrowsAsync,
 } from "https://deno.land/std@0.113.0/testing/asserts.ts";
-export {
-  format as formatDate,
-  parse as parseDate,
-} from "https://deno.land/std@0.113.0/datetime/mod.ts";
 export { fromFileUrl } from "https://deno.land/std@0.113.0/path/mod.ts";


### PR DESCRIPTION
The previous implementation had some important flaws that went unnoticed until now, this simply replaces it with std/date parsing