### PR TITLE
Feat: Named query parameters #223

### DIFF
--- a/query/query.ts
+++ b/query/query.ts
@@ -363,10 +363,8 @@ export class Query<T extends ResultType> {
         origObj = undefined;
       }
       if (origObj != undefined) {
-        console.log("#keys: " + Object.keys(origObj).length);
         for (let argPos = 1; argPos <= Object.keys(origObj).length; argPos++) {
           strPos = str.indexOf("$", strPos);
-          console.log("sp: " + strPos);
           strPos++;
           const wordLen = str.slice(strPos).search(/(?:\s+|$|:|,)/);
           const arg = str.slice(strPos, strPos + wordLen);


### PR DESCRIPTION
I'm using this fork already  for some time in my projects and it works as expected.
Current version assumes parameters being case INSENSITIVE  (nAmE == NaME) ! please advise if it's in accordance with your guidelines?
I have added couple of test cases for named arguments, all tests pass!

Best

Marko