### PR TITLE
chore: Fix deprecated dependencies

### DIFF
--- a/connection/auth.ts
+++ b/connection/auth.ts
@@ -1,25 +1,28 @@
-import { Md5 } from "../deps.ts";
+import { crypto, hex } from "../deps.ts";
 
 const encoder = new TextEncoder();
+const decoder = new TextDecoder();
 
-function md5(bytes: Uint8Array): string {
-  return new Md5().update(bytes).toString("hex");
+async function md5(bytes: Uint8Array): Promise<string> {
+  return decoder.decode(
+    hex.encode(new Uint8Array(await crypto.subtle.digest("MD5", bytes))),
+  );
 }
 
 // AuthenticationMD5Password
 // The actual PasswordMessage can be computed in SQL as:
 //  concat('md5', md5(concat(md5(concat(password, username)), random-salt))).
 // (Keep in mind the md5() function returns its result as a hex string.)
-export function hashMd5Password(
+export async function hashMd5Password(
   password: string,
   username: string,
   salt: Uint8Array,
-): string {
-  const innerHash = md5(encoder.encode(password + username));
+): Promise<string> {
+  const innerHash = await md5(encoder.encode(password + username));
   const innerBytes = encoder.encode(innerHash);
   const outerBuffer = new Uint8Array(innerBytes.length + salt.length);
   outerBuffer.set(innerBytes);
   outerBuffer.set(salt, innerBytes.length);
-  const outerHash = md5(outerBuffer);
+  const outerHash = await md5(outerBuffer);
   return "md5" + outerHash;
 }

--- a/connection/connection.ts
+++ b/connection/connection.ts
@@ -552,7 +552,7 @@ export class Connection {
       );
     }
 
-    const password = hashMd5Password(
+    const password = await hashMd5Password(
       this.#connection_params.password,
       this.#connection_params.user,
       salt,

--- a/deps.ts
+++ b/deps.ts
@@ -1,11 +1,12 @@
 export * as base64 from "https://deno.land/std@0.114.0/encoding/base64.ts";
+export * as hex from "https://deno.land/std@0.114.0/encoding/hex.ts";
 export * as date from "https://deno.land/std@0.114.0/datetime/mod.ts";
 export {
   BufReader,
   BufWriter,
 } from "https://deno.land/std@0.114.0/io/buffer.ts";
 export { copy } from "https://deno.land/std@0.114.0/bytes/mod.ts";
-export { Md5 } from "https://deno.land/std@0.114.0/hash/md5.ts";
+export { crypto } from "https://deno.land/std@0.114.0/crypto/mod.ts";
 export { deferred, delay } from "https://deno.land/std@0.114.0/async/mod.ts";
 export type { Deferred } from "https://deno.land/std@0.114.0/async/mod.ts";
 export { bold, yellow } from "https://deno.land/std@0.114.0/fmt/colors.ts";

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -1,8 +1,4 @@
-import {
-  assertEquals,
-  assertNotEquals,
-  assertThrowsAsync,
-} from "./test_deps.ts";
+import { assertEquals, assertNotEquals, assertRejects } from "./test_deps.ts";
 import { Client as ScramClient, Reason } from "../connection/scram.ts";
 
 Deno.test("Scram client reproduces RFC 7677 example", async () => {
@@ -36,7 +32,7 @@ Deno.test("Scram client catches bad server nonce", async () => {
   for (const testCase of testCases) {
     const client = new ScramClient("user", "password", "nonce1");
     client.composeChallenge();
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.receiveChallenge(testCase),
       Error,
       Reason.BadServerNonce,
@@ -52,7 +48,7 @@ Deno.test("Scram client catches bad salt", async () => {
   for (const testCase of testCases) {
     const client = new ScramClient("user", "password", "nonce1");
     client.composeChallenge();
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.receiveChallenge(testCase),
       Error,
       Reason.BadSalt,
@@ -71,7 +67,7 @@ Deno.test("Scram client catches bad iteration count", async () => {
   for (const testCase of testCases) {
     const client = new ScramClient("user", "password", "nonce1");
     client.composeChallenge();
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.receiveChallenge(testCase),
       Error,
       Reason.BadIterationCount,
@@ -84,7 +80,7 @@ Deno.test("Scram client catches bad verifier", async () => {
   client.composeChallenge();
   await client.receiveChallenge("r=nonce12,s=c2FsdA==,i=4096");
   await client.composeResponse();
-  await assertThrowsAsync(
+  await assertRejects(
     () => client.receiveResponse("v=xxxx"),
     Error,
     Reason.BadVerifier,
@@ -98,7 +94,7 @@ Deno.test("Scram client catches server rejection", async () => {
   await client.composeResponse();
 
   const message = "auth error";
-  await assertThrowsAsync(
+  await assertRejects(
     () => client.receiveResponse(`e=${message}`),
     Error,
     message,

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,6 +1,6 @@
 import {
   assertEquals,
-  assertThrowsAsync,
+  assertRejects,
   deferred,
   joinPath,
   streams,
@@ -172,7 +172,7 @@ Deno.test("Skips TLS connection when TLS disabled", async () => {
 
   // Connection will fail due to TLS only user
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.connect(),
       PostgresError,
       "no pg_hba.conf",
@@ -198,7 +198,7 @@ Deno.test("Aborts TLS connection when certificate is untrusted", async () => {
   });
 
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       async (): Promise<void> => {
         await client.connect();
       },
@@ -239,7 +239,7 @@ Deno.test("Handles bad authentication correctly", async function () {
   const client = new Client(badConnectionData);
 
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       async (): Promise<void> => {
         await client.connect();
       },
@@ -259,7 +259,7 @@ Deno.test("Startup error when database does not exist", async function () {
   const client = new Client(badConnectionData);
 
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       async (): Promise<void> => {
         await client.connect();
       },
@@ -326,7 +326,7 @@ Deno.test("Exposes session transport", async () => {
 });
 
 Deno.test("Attempts to guess socket route", async () => {
-  await assertThrowsAsync(
+  await assertRejects(
     async () => {
       const mock_socket = await Deno.makeTempFile({
         prefix: ".postgres_socket.",
@@ -348,7 +348,7 @@ Deno.test("Attempts to guess socket route", async () => {
   const path = await Deno.makeTempDir({ prefix: "postgres_socket" });
   const port = 1234;
 
-  await assertThrowsAsync(
+  await assertRejects(
     async () => {
       const client = new Client({
         database: "some_database",
@@ -534,7 +534,7 @@ Deno.test("Attempts reconnection on disconnection", async function () {
     await client.queryArray(`DROP TABLE IF EXISTS ${test_table}`);
     await client.queryArray(`CREATE TABLE ${test_table} (X INT)`);
 
-    await assertThrowsAsync(
+    await assertRejects(
       () =>
         client.queryArray(
           `INSERT INTO ${test_table} VALUES (${test_value}); COMMIT; SELECT PG_TERMINATE_BACKEND(${client.session.pid})`,
@@ -576,7 +576,7 @@ Deno.test("Attempts reconnection on socket disconnection", async () => {
   await client.connect();
 
   try {
-    await assertThrowsAsync(
+    await assertRejects(
       () =>
         client.queryArray`SELECT PG_TERMINATE_BACKEND(${client.session.pid})`,
       ConnectionError,
@@ -617,7 +617,7 @@ Deno.test("Attempts reconnection when connection is lost", async function () {
   // a new connection should be established.
   aborter.abort();
 
-  await assertThrowsAsync(
+  await assertRejects(
     () => client.queryObject("SELECT 1"),
     ConnectionError,
     "The session was terminated unexpectedly",
@@ -639,12 +639,12 @@ Deno.test("Doesn't attempt reconnection when attempts are set to zero", async fu
   await client.connect();
 
   try {
-    await assertThrowsAsync(() =>
+    await assertRejects(() =>
       client.queryArray`SELECT PG_TERMINATE_BACKEND(${client.session.pid})`
     );
     assertEquals(client.connected, false);
 
-    await assertThrowsAsync(
+    await assertRejects(
       () => client.queryArray`SELECT 1`,
       Error,
       "The client has been disconnected from the database",

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -4,7 +4,7 @@ export {
   assertEquals,
   assertNotEquals,
   assertObjectMatch,
+  assertRejects,
   assertThrows,
-  assertThrowsAsync,
 } from "https://deno.land/std@0.114.0/testing/asserts.ts";
 export * as streams from "https://deno.land/std@0.114.0/streams/conversion.ts";


### PR DESCRIPTION
This increases library size by a good chunk, still negligible though considering std/hash would have been removed eventually

Before: `dependencies: 52 unique (total 315.58KB)`
After: `dependencies: 55 unique (total 521.96KB)`