### PR TITLE
Add more type safety to connect string

### DIFF
--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -17,7 +17,7 @@ import { fromFileUrl, isAbsolute } from "../deps.ts";
  * - sslmode
  * - user
  */
-export type ConnectionString = string;
+export type ConnectionString = `postgres://${string}`;
 
 /**
  * This function retrieves the connection options from the environmental variables


### PR DESCRIPTION
Using Template Literal Types

Docs 📖 https://www.typescriptlang.org/docs/handbook/2/template-literal-types.html

With this, I'm securing that any connection string starts with `postgres://`

Maybe I could be more specific, like

```typescript
export type ConnectionStringFullOptions = `postgres://${string}:${string}@${string}:${string}/${string}?${string}`;
export type ConnectionString = `postgres://${string}` | ConnectionStringFullOptions // | other | otherCase
```

ConnectionStringFullOptions is user, password, hostname, port, database, queries...

If an approach like this is wanted I can give it a try 😆 