### PR TITLE
fix: concurrent connect-then-release cycles do not throw (#378)

### DIFF
--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -125,3 +125,18 @@ Deno.test(
     true,
   ),
 );
+
+Deno.test(
+  "Concurrent connect-then-release cycles do not throw",
+  testPool(async (POOL) => {
+    async function connectThenRelease() {
+      let client = await POOL.connect();
+      client.release();
+      client = await POOL.connect();
+      client.release();
+    }
+    await Promise.all(
+      Array.from({ length: POOL.size + 1 }, connectThenRelease),
+    );
+  }),
+);


### PR DESCRIPTION
This PR fixes #378 (concurrent connect-then-release cycles may throw) by modifying `DeferredAccessStack` (`push` and `pop` to be specific). `deferred.resolve` and `await d` is executed asynchronously (other statements may be executed in between); access to `#elements` is not performed as expected (racing happens).

I see some overlapping logic between `DeferredStack` and `DeferredAccessStack`. To keep consistency, `push` and `pop` of `DeferredStack` are also modified using the same pattern. `#array` is also renamed to `#elements`. I am not sure if the modification to `DeferredStack` solves real-world problems but I think there’re chances these two classes will be consolidated/combined/refactored I do not want such discrepancy confuses somebody then.

A test case is included. Please let me know if there’s something to improve.