### PR TITLE
Specify length in SCRAM deriveKeySignatures

### DIFF
--- a/connection/scram.ts
+++ b/connection/scram.ts
@@ -110,7 +110,7 @@ async function deriveKeySignatures(
       salt,
     },
     pbkdf2_password,
-    { name: "HMAC", hash: "SHA-256" },
+    { name: "HMAC", hash: "SHA-256", length: 256 },
     false,
     ["sign"],
   );


### PR DESCRIPTION
Hi! We were playing with this﻿ library and tried to use it from the browser. SCRAM implementation didn't work for us and after some investigation, we found a bug in Deno (https://github.com/denoland/deno/issues/16180) which was responsible for the issue.

The bug is that HMAC/SHA-256 object for `deriveKey` also has an optional `length` field, which is different in the browser and Deno. After explicitly specifying `length: 256`, SCRAM works well both in Deno and browser/cloudflare workers.
