### PR TITLE
deps(std): bump dependencies and prefer their lighter submodules

### DIFF
--- a/connection/auth.ts
+++ b/connection/auth.ts
@@ -1,12 +1,9 @@
 import { crypto, hex } from "../deps.ts";
 
 const encoder = new TextEncoder();
-const decoder = new TextDecoder();
 
 async function md5(bytes: Uint8Array): Promise<string> {
-  return decoder.decode(
-    hex.encode(new Uint8Array(await crypto.subtle.digest("MD5", bytes))),
-  );
+  return hex.encodeHex(await crypto.subtle.digest("MD5", bytes));
 }
 
 // AuthenticationMD5Password

--- a/connection/scram.ts
+++ b/connection/scram.ts
@@ -134,7 +134,7 @@ function escape(str: string): string {
 }
 
 function generateRandomNonce(size: number): string {
-  return base64.encode(crypto.getRandomValues(new Uint8Array(size)));
+  return base64.encodeBase64(crypto.getRandomValues(new Uint8Array(size)));
 }
 
 function parseScramAttributes(message: string): Record<string, string> {
@@ -223,7 +223,7 @@ export class Client {
         throw new Error(Reason.BadSalt);
       }
       try {
-        salt = base64.decode(attrs.s);
+        salt = base64.decodeBase64(attrs.s);
       } catch {
         throw new Error(Reason.BadSalt);
       }
@@ -261,7 +261,7 @@ export class Client {
 
       this.#auth_message += "," + responseWithoutProof;
 
-      const proof = base64.encode(
+      const proof = base64.encodeBase64(
         computeScramProof(
           await computeScramSignature(
             this.#auth_message,
@@ -294,7 +294,7 @@ export class Client {
         throw new Error(attrs.e ?? Reason.Rejected);
       }
 
-      const verifier = base64.encode(
+      const verifier = base64.encodeBase64(
         await computeScramSignature(
           this.#auth_message,
           this.#key_signatures.server,

--- a/deps.ts
+++ b/deps.ts
@@ -3,7 +3,7 @@ export * as hex from "https://deno.land/std@0.180.0/encoding/hex.ts";
 export * as date from "https://deno.land/std@0.180.0/datetime/mod.ts";
 export { BufReader } from "https://deno.land/std@0.180.0/io/buf_reader.ts";
 export { BufWriter } from "https://deno.land/std@0.180.0/io/buf_writer.ts";
-export { copy } from "https://deno.land/std@0.180.0/bytes/mod.ts";
+export { copy } from "https://deno.land/std@0.180.0/bytes/copy.ts";
 export { crypto } from "https://deno.land/std@0.180.0/crypto/mod.ts";
 export {
   type Deferred,

--- a/deps.ts
+++ b/deps.ts
@@ -1,10 +1,8 @@
 export * as base64 from "https://deno.land/std@0.180.0/encoding/base64.ts";
 export * as hex from "https://deno.land/std@0.180.0/encoding/hex.ts";
 export * as date from "https://deno.land/std@0.180.0/datetime/mod.ts";
-export {
-  BufReader,
-  BufWriter,
-} from "https://deno.land/std@0.180.0/io/buffer.ts";
+export { BufReader } from "https://deno.land/std@0.180.0/io/buf_reader.ts";
+export { BufWriter } from "https://deno.land/std@0.180.0/io/buf_writer.ts";
 export { copy } from "https://deno.land/std@0.180.0/bytes/mod.ts";
 export { crypto } from "https://deno.land/std@0.180.0/crypto/mod.ts";
 export {

--- a/deps.ts
+++ b/deps.ts
@@ -4,7 +4,7 @@ export * as date from "https://deno.land/std@0.180.0/datetime/mod.ts";
 export { BufReader } from "https://deno.land/std@0.180.0/io/buf_reader.ts";
 export { BufWriter } from "https://deno.land/std@0.180.0/io/buf_writer.ts";
 export { copy } from "https://deno.land/std@0.180.0/bytes/copy.ts";
-export { crypto } from "https://deno.land/std@0.180.0/crypto/mod.ts";
+export { crypto } from "https://deno.land/std@0.180.0/crypto/crypto.ts";
 export {
   type Deferred,
   deferred,

--- a/deps.ts
+++ b/deps.ts
@@ -8,8 +8,8 @@ export { crypto } from "https://deno.land/std@0.180.0/crypto/crypto.ts";
 export {
   type Deferred,
   deferred,
-  delay,
-} from "https://deno.land/std@0.180.0/async/mod.ts";
+} from "https://deno.land/std@0.180.0/async/deferred.ts";
+export { delay } from "https://deno.land/std@0.180.0/async/delay.ts";
 export { bold, yellow } from "https://deno.land/std@0.180.0/fmt/colors.ts";
 export {
   fromFileUrl,

--- a/deps.ts
+++ b/deps.ts
@@ -1,18 +1,14 @@
-export * as base64 from "https://deno.land/std@0.180.0/encoding/base64.ts";
-export * as hex from "https://deno.land/std@0.180.0/encoding/hex.ts";
-export { parse as parseDate } from "https://deno.land/std@0.180.0/datetime/parse.ts";
-export { BufReader } from "https://deno.land/std@0.180.0/io/buf_reader.ts";
-export { BufWriter } from "https://deno.land/std@0.180.0/io/buf_writer.ts";
-export { copy } from "https://deno.land/std@0.180.0/bytes/copy.ts";
-export { crypto } from "https://deno.land/std@0.180.0/crypto/crypto.ts";
-export {
-  type Deferred,
-  deferred,
-} from "https://deno.land/std@0.180.0/async/deferred.ts";
-export { delay } from "https://deno.land/std@0.180.0/async/delay.ts";
-export { bold, yellow } from "https://deno.land/std@0.180.0/fmt/colors.ts";
+export * as base64 from "https://deno.land/std@0.214.0/encoding/base64.ts";
+export * as hex from "https://deno.land/std@0.214.0/encoding/hex.ts";
+export { parse as parseDate } from "https://deno.land/std@0.214.0/datetime/parse.ts";
+export { BufReader } from "https://deno.land/std@0.214.0/io/buf_reader.ts";
+export { BufWriter } from "https://deno.land/std@0.214.0/io/buf_writer.ts";
+export { copy } from "https://deno.land/std@0.214.0/bytes/copy.ts";
+export { crypto } from "https://deno.land/std@0.214.0/crypto/crypto.ts";
+export { delay } from "https://deno.land/std@0.214.0/async/delay.ts";
+export { bold, yellow } from "https://deno.land/std@0.214.0/fmt/colors.ts";
 export {
   fromFileUrl,
   isAbsolute,
   join as joinPath,
-} from "https://deno.land/std@0.180.0/path/mod.ts";
+} from "https://deno.land/std@0.214.0/path/mod.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,6 +1,6 @@
 export * as base64 from "https://deno.land/std@0.180.0/encoding/base64.ts";
 export * as hex from "https://deno.land/std@0.180.0/encoding/hex.ts";
-export * as date from "https://deno.land/std@0.180.0/datetime/mod.ts";
+export { parse as parseDate } from "https://deno.land/std@0.180.0/datetime/parse.ts";
 export { BufReader } from "https://deno.land/std@0.180.0/io/buf_reader.ts";
 export { BufWriter } from "https://deno.land/std@0.180.0/io/buf_writer.ts";
 export { copy } from "https://deno.land/std@0.180.0/bytes/copy.ts";

--- a/deps.ts
+++ b/deps.ts
@@ -1,20 +1,20 @@
-export * as base64 from "https://deno.land/std@0.160.0/encoding/base64.ts";
-export * as hex from "https://deno.land/std@0.160.0/encoding/hex.ts";
-export * as date from "https://deno.land/std@0.160.0/datetime/mod.ts";
+export * as base64 from "https://deno.land/std@0.180.0/encoding/base64.ts";
+export * as hex from "https://deno.land/std@0.180.0/encoding/hex.ts";
+export * as date from "https://deno.land/std@0.180.0/datetime/mod.ts";
 export {
   BufReader,
   BufWriter,
-} from "https://deno.land/std@0.160.0/io/buffer.ts";
-export { copy } from "https://deno.land/std@0.160.0/bytes/mod.ts";
-export { crypto } from "https://deno.land/std@0.160.0/crypto/mod.ts";
+} from "https://deno.land/std@0.180.0/io/buffer.ts";
+export { copy } from "https://deno.land/std@0.180.0/bytes/mod.ts";
+export { crypto } from "https://deno.land/std@0.180.0/crypto/mod.ts";
 export {
   type Deferred,
   deferred,
   delay,
-} from "https://deno.land/std@0.160.0/async/mod.ts";
-export { bold, yellow } from "https://deno.land/std@0.160.0/fmt/colors.ts";
+} from "https://deno.land/std@0.180.0/async/mod.ts";
+export { bold, yellow } from "https://deno.land/std@0.180.0/fmt/colors.ts";
 export {
   fromFileUrl,
   isAbsolute,
   join as joinPath,
-} from "https://deno.land/std@0.160.0/path/mod.ts";
+} from "https://deno.land/std@0.180.0/path/mod.ts";

--- a/query/decoders.ts
+++ b/query/decoders.ts
@@ -1,4 +1,4 @@
-import { date } from "../deps.ts";
+import { parseDate } from "../deps.ts";
 import { parseArray } from "./array_parser.ts";
 import type {
   Box,
@@ -127,7 +127,7 @@ export function decodeDate(dateStr: string): Date | number {
     return Number(-Infinity);
   }
 
-  return date.parse(dateStr, "yyyy-MM-dd");
+  return parseDate(dateStr, "yyyy-MM-dd");
 }
 
 export function decodeDateArray(value: string) {

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -2,7 +2,6 @@ import {
   assertEquals,
   assertRejects,
   copyStream,
-  deferred,
   joinPath,
 } from "./test_deps.ts";
 import {
@@ -374,15 +373,15 @@ Deno.test("Closes connection on bad TLS availability verification", async functi
   );
 
   // Await for server initialization
-  const initialized = deferred();
+  const initialized = Promise.withResolvers();
   server.onmessage = ({ data }) => {
     if (data !== "initialized") {
       initialized.reject(`Unexpected message "${data}" received from worker`);
     }
-    initialized.resolve();
+    initialized.resolve(null);
   };
   server.postMessage("initialize");
-  await initialized;
+  await initialized.promise;
 
   const client = new Client({
     database: "none",
@@ -413,17 +412,17 @@ Deno.test("Closes connection on bad TLS availability verification", async functi
     await client.end();
   }
 
-  const closed = deferred();
+  const closed = Promise.withResolvers();
   server.onmessage = ({ data }) => {
     if (data !== "closed") {
       closed.reject(
         `Unexpected message "${data}" received from worker`,
       );
     }
-    closed.resolve();
+    closed.resolve(null);
   };
   server.postMessage("close");
-  await closed;
+  await closed.promise;
   server.terminate();
 
   assertEquals(bad_tls_availability_message, true);
@@ -438,15 +437,15 @@ async function mockReconnection(attempts: number) {
   );
 
   // Await for server initialization
-  const initialized = deferred();
+  const initialized = Promise.withResolvers();
   server.onmessage = ({ data }) => {
     if (data !== "initialized") {
       initialized.reject(`Unexpected message "${data}" received from worker`);
     }
-    initialized.resolve();
+    initialized.resolve(null);
   };
   server.postMessage("initialize");
-  await initialized;
+  await initialized.promise;
 
   const client = new Client({
     connection: {
@@ -483,17 +482,17 @@ async function mockReconnection(attempts: number) {
     await client.end();
   }
 
-  const closed = deferred();
+  const closed = Promise.withResolvers();
   server.onmessage = ({ data }) => {
     if (data !== "closed") {
       closed.reject(
         `Unexpected message "${data}" received from worker`,
       );
     }
-    closed.resolve();
+    closed.resolve(null);
   };
   server.postMessage("close");
-  await closed;
+  await closed.promise;
   server.terminate();
 
   // If reconnections are set to zero, it will attempt to connect at least once, but won't

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,9 +1,9 @@
 import {
   assertEquals,
   assertRejects,
+  copyStream,
   deferred,
   joinPath,
-  streams,
 } from "./test_deps.ts";
 import {
   getClearConfiguration,
@@ -38,8 +38,8 @@ function createProxy(
         aborted = true;
       });
       await Promise.all([
-        streams.copy(conn, outbound),
-        streams.copy(outbound, conn),
+        copyStream(conn, outbound),
+        copyStream(outbound, conn),
       ]).catch(() => {});
 
       if (!aborted) {

--- a/tests/data_types_test.ts
+++ b/tests/data_types_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, base64, date } from "./test_deps.ts";
+import { assertEquals, base64, formatDate, parseDate } from "./test_deps.ts";
 import { getMainConfiguration } from "./config.ts";
 import { generateSimpleClientTest } from "./helpers.ts";
 import type {
@@ -931,7 +931,7 @@ Deno.test(
     );
 
     assertEquals(result.rows[0], [
-      date.parse(date_text, "yyyy-MM-dd"),
+      parseDate(date_text, "yyyy-MM-dd"),
       Infinity,
     ]);
   }),
@@ -941,7 +941,7 @@ Deno.test(
   "date array",
   testClient(async (client) => {
     await client.queryArray(`SET SESSION TIMEZONE TO '${timezone}'`);
-    const dates = ["2020-01-01", date.format(new Date(), "yyyy-MM-dd")];
+    const dates = ["2020-01-01", formatDate(new Date(), "yyyy-MM-dd")];
 
     const { rows: result } = await client.queryArray<[[Date, Date]]>(
       "SELECT ARRAY[$1::DATE, $2]",
@@ -950,7 +950,7 @@ Deno.test(
 
     assertEquals(
       result[0][0],
-      dates.map((d) => date.parse(d, "yyyy-MM-dd")),
+      dates.map((d) => parseDate(d, "yyyy-MM-dd")),
     );
   }),
 );

--- a/tests/data_types_test.ts
+++ b/tests/data_types_test.ts
@@ -34,7 +34,7 @@ function generateRandomPoint(max_value = 100): Point {
 
 const CHARS = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 function randomBase64(): string {
-  return base64.encode(
+  return base64.encodeBase64(
     Array.from(
       { length: Math.ceil(Math.random() * 256) },
       () => CHARS[Math.floor(Math.random() * CHARS.length)],
@@ -671,7 +671,7 @@ Deno.test(
       `SELECT decode('${base64_string}','base64')`,
     );
 
-    assertEquals(result.rows[0][0], base64.decode(base64_string));
+    assertEquals(result.rows[0][0], base64.decodeBase64(base64_string));
   }),
 );
 
@@ -691,7 +691,7 @@ Deno.test(
 
     assertEquals(
       result.rows[0][0],
-      strings.map(base64.decode),
+      strings.map(base64.decodeBase64),
     );
   }),
 );

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -6,6 +6,6 @@ export {
   assertObjectMatch,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.214.0/testing/asserts.ts";
+} from "https://deno.land/std@0.214.0/assert/mod.ts";
 export { format as formatDate } from "https://deno.land/std@0.214.0/datetime/format.ts";
-export { copy as copyStream } from "https://deno.land/std@0.214.0/streams/copy.ts";
+export { copy as copyStream } from "https://deno.land/std@0.214.0/io/copy.ts";

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -7,4 +7,5 @@ export {
   assertRejects,
   assertThrows,
 } from "https://deno.land/std@0.180.0/testing/asserts.ts";
-export * as streams from "https://deno.land/std@0.180.0/streams/conversion.ts";
+export { format as formatDate } from "https://deno.land/std@0.180.0/datetime/format.ts";
+export { copy as copyStream } from "https://deno.land/std@0.180.0/streams/copy.ts";

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -6,6 +6,6 @@ export {
   assertObjectMatch,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.180.0/testing/asserts.ts";
-export { format as formatDate } from "https://deno.land/std@0.180.0/datetime/format.ts";
-export { copy as copyStream } from "https://deno.land/std@0.180.0/streams/copy.ts";
+} from "https://deno.land/std@0.214.0/testing/asserts.ts";
+export { format as formatDate } from "https://deno.land/std@0.214.0/datetime/format.ts";
+export { copy as copyStream } from "https://deno.land/std@0.214.0/streams/copy.ts";

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -6,5 +6,5 @@ export {
   assertObjectMatch,
   assertRejects,
   assertThrows,
-} from "https://deno.land/std@0.160.0/testing/asserts.ts";
-export * as streams from "https://deno.land/std@0.160.0/streams/conversion.ts";
+} from "https://deno.land/std@0.180.0/testing/asserts.ts";
+export * as streams from "https://deno.land/std@0.180.0/streams/conversion.ts";

--- a/utils/deferred.ts
+++ b/utils/deferred.ts
@@ -1,4 +1,4 @@
-import { type Deferred, deferred } from "../deps.ts";
+export type Deferred<T> = ReturnType<typeof Promise.withResolvers<T>>;
 
 export class DeferredStack<T> {
   #elements: Array<T>;
@@ -30,9 +30,9 @@ export class DeferredStack<T> {
       this.#size++;
       return await this.#creator();
     }
-    const d = deferred<T>();
+    const d = Promise.withResolvers<T>();
     this.#queue.push(d);
-    return await d;
+    return await d.promise;
   }
 
   push(value: T): void {
@@ -112,9 +112,9 @@ export class DeferredAccessStack<T> {
     } else {
       // If there are not elements left in the stack, it will await the call until
       // at least one is restored and then return it
-      const d = deferred<T>();
+      const d = Promise.withResolvers<T>();
       this.#queue.push(d);
-      element = await d;
+      element = await d.promise;
     }
 
     if (!await this.#checkElementInitialization(element)) {


### PR DESCRIPTION
This PR bumps the `std` dependencies from `0.160.0` to the latest `0.180.0` (as of writing). Breaking changes upstream (i.e., renamed exports, moved files, etc.) have been addressed accordingly.

While I was bumping the versions, I also refactored some exports such that we now prefer importing submodules instead of the more general `mod.ts` files (which downloads a bunch of unneeded files).