### PR TITLE
`mod.ts`: check for appropriate v8 version

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,3 +1,8 @@
+// Check for minimum supported V8 runtime version
+if(Number(Deno.version.v8.split(".")[0]) < 12) {
+  throw new Error("deno-postgres requires at least Deno v1.38 including V8 v12 or later.")
+}
+
 export { Client } from "./client.ts";
 export {
   ConnectionError,

--- a/mod.ts
+++ b/mod.ts
@@ -1,5 +1,5 @@
 // Check for minimum supported V8 runtime version
-if(Number(Deno.version.v8.split(".")[0]) < 12) {
+if(Deno.version.deno >= 1.38) {
   throw new Error("deno-postgres requires at least Deno v1.38 including V8 v12 or later.")
 }
 


### PR DESCRIPTION
We run `deno-postgres` for some of our API services. During a recent upgrade we had query failures due to no support for `Promise.withResolvers()`. This change adds a check for at least V8 version 12 where that API was added.