### PR TITLE
Allow `using` keyword with pool clients

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -515,4 +515,8 @@ export class PoolClient extends QueryClient {
     // Cleanup all session related metadata
     this.resetSessionMetadata();
   }
+
+  [Symbol.dispose]() {
+    this.release();
+  }
 }

--- a/query/array_parser.ts
+++ b/query/array_parser.ts
@@ -20,7 +20,7 @@ export function parseArray<T>(
   source: string,
   transform: Transformer<T>,
   separator: AllowedSeparators = ",",
-) {
+): ArrayResult<T> {
   return new ArrayParser(source, transform, separator).parse();
 }
 

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -140,3 +140,15 @@ Deno.test(
     );
   }),
 );
+
+Deno.test(
+  "Pool client will be released after `using` block",
+  testPool(async (POOL) => {
+    const initialPoolAvailable = POOL.available;
+    {
+      using _client = await POOL.connect();
+      assertEquals(POOL.available, initialPoolAvailable - 1);
+    }
+    assertEquals(POOL.available, initialPoolAvailable);
+  }),
+);


### PR DESCRIPTION
Related to #472

- [x] PoolClient
- [x] test for `using client = await POOL.connect();`