### PR TITLE
chore: correct formatting strategy for publishing on JSR

### DIFF
--- a/.github/workflows/publish_jsr.yml
+++ b/.github/workflows/publish_jsr.yml
@@ -22,12 +22,15 @@ jobs:
 
       - name: Set up Deno
         uses: denoland/setup-deno@v1
+        
+      - name: Check Format
+        run: deno fmt --check
 
       - name: Convert to JSR package
         run: deno run -A tools/convert_to_jsr.ts
 
-      - name: Format
-        run: deno fmt --check
+      - name: Format converted code
+        run: deno fmt
       
       - name: Lint
         run: deno lint


### PR DESCRIPTION
Currently, the workflow to publish on jsr first modifies the imports, then checks if the formatting is correct.
Since the new imports are shorter, it can happen that an import statements spanning multiple lines, becomes short enough to fit in a single line (which `deno fmt` mandates).

A solution, as proposed in this PR, is to check the formatting before converting the code, and then reformat again after the code is converted.