### PR TITLE
fix: Deno 2 permissions system update for ENV

### DIFF
--- a/connection/connection_params.ts
+++ b/connection/connection_params.ts
@@ -420,7 +420,10 @@ export function createParams(
   try {
     pgEnv = getPgEnv();
   } catch (e) {
-    if (e instanceof Deno.errors.PermissionDenied) {
+    // In Deno v1, Deno permission errors resulted in a Deno.errors.PermissionDenied exception. In Deno v2, a new
+    // Deno.errors.NotCapable exception was added to replace this. The "in" check makes this code safe for both Deno
+    // 1 and Deno 2
+    if (e instanceof Deno.errors.PermissionDenied || ('NotCapable' in Deno.errors && e instanceof Deno.errors.NotCapable)) {
       has_env_access = false;
     } else {
       throw e;

--- a/tests/config.ts
+++ b/tests/config.ts
@@ -15,7 +15,7 @@ let DEV_MODE: string | undefined;
 try {
   DEV_MODE = Deno.env.get("DENO_POSTGRES_DEVELOPMENT");
 } catch (e) {
-  if (e instanceof Deno.errors.PermissionDenied) {
+  if (e instanceof Deno.errors.PermissionDenied || ('NotCapable' in Deno.errors && e instanceof Deno.errors.NotCapable)) {
     throw new Error(
       "You need to provide ENV access in order to run the test suite",
     );


### PR DESCRIPTION
Updates usages of of `Deno.errors.PermissionDenied` to also support Deno v2's new `Deno.errors.NotCapable`.

Fixes #491