### PR TITLE
fix(cd): allow publish of formatted/converted code

### DIFF
--- a/.github/workflows/publish_jsr.yml
+++ b/.github/workflows/publish_jsr.yml
@@ -46,8 +46,8 @@ jobs:
 
       - name: Publish (dry run)
         if: startsWith(github.ref, 'refs/tags/') == false
-        run: deno publish --dry-run
+        run: deno publish --dry-run --allow-dirty
 
       - name: Publish (real)
         if: startsWith(github.ref, 'refs/tags/')
-        run: deno publish
+        run: deno publish --allow-dirty


### PR DESCRIPTION
Current JSR package is lagging behind because this job has been failing due to the uncommitted change check, which clashes with formatting & converting steps.