### PR TITLE
fix JSR publish workflow

### DIFF
--- a/.github/workflows/publish_jsr.yml
+++ b/.github/workflows/publish_jsr.yml
@@ -34,14 +34,14 @@ jobs:
       - name: Lint
         run: deno lint
 
-      - name: Documentation tests
-        run: deno test --doc client.ts mod.ts pool.ts client/ connection/ query/ utils/
-
       - name: Build tests container
         run: docker compose build tests
 
       - name: Run tests
         run: docker compose run tests
+
+      - name: Run doc tests
+        run: docker compose run doc_tests
 
       - name: Publish (dry run)
         if: startsWith(github.ref, 'refs/tags/') == false


### PR DESCRIPTION
it seems in my efforts to fix the docs tests, I forgot to update the JSR publish workflow. this pr fixes that workflow and it should pass just fine, assuming someone creates the `@db/postgres` package under the JSR scope and links this Github repo