### PR TITLE
Auto-reconnect on `BrokenPipe` outside transactions

### DIFF
--- a/client.ts
+++ b/client.ts
@@ -274,7 +274,18 @@ export abstract class QueryClient {
     _query: Query<ResultType.OBJECT>,
   ): Promise<QueryObjectResult<T>>;
   async #executeQuery(query: Query<ResultType>): Promise<QueryResult> {
-    return await this.#connection.query(query);
+    try {
+      return await this.#connection.query(query);
+    } catch (e) {
+      if (e instanceof Deno.errors.BrokenPipe) {
+        // Retry once with fresh connection, if connection was dropped by server since last query
+        await this.closeConnection();
+        await this.connect();
+        return await this.#connection.query(query);
+      } else {
+        throw e;
+      }
+    }
   }
 
   /**

--- a/client.ts
+++ b/client.ts
@@ -231,8 +231,14 @@ export abstract class QueryClient {
       name,
       options,
       this,
-      // Bind context so function can be passed as is
-      this.#executeQuery.bind(this),
+      // Pass in callback to lower-level connection, to avoid our retry logic
+      // for non-transactional queries
+      this.#connection.query.bind(this.#connection),
+      // Lower-level reconnect callback to handle dropped connections in `.begin()`
+      async () => {
+        await this.closeConnection();
+        await this.connect();
+      },
       (name: string | null) => {
         this.#transaction = name;
       },

--- a/client/error.ts
+++ b/client/error.ts
@@ -58,7 +58,10 @@ export class TransactionError extends Error {
   /**
    * Create a transaction error with a message and a cause
    */
-  constructor(transaction_name: string, cause: PostgresError) {
+  constructor(
+    transaction_name: string,
+    cause: PostgresError | Deno.errors.BrokenPipe,
+  ) {
     super(`The transaction "${transaction_name}" has been aborted`, { cause });
     this.name = "TransactionError";
   }

--- a/connection/connection.ts
+++ b/connection/connection.ts
@@ -1012,8 +1012,8 @@ export class Connection {
   async end(): Promise<void> {
     if (this.connected) {
       const terminationMessage = new Uint8Array([0x58, 0x00, 0x00, 0x00, 0x04]);
-      await this.#connWritable.write(terminationMessage);
       try {
+        await this.#connWritable.write(terminationMessage);
         await this.#connWritable.ready;
       } catch (_e) {
         // This steps can fail if the underlying connection was closed ungracefully

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,9 @@
     "@std/crypto": "jsr:@std/crypto@^1.0.4",
     "@std/encoding": "jsr:@std/encoding@^1.0.9",
     "@std/fmt": "jsr:@std/fmt@^1.0.6",
-    "@std/path": "jsr:@std/path@^1.0.8"
+    "@std/path": "jsr:@std/path@^1.0.8",
+    "@std/assert": "jsr:@std/assert@^1.0.10",
+    "@std/testing": "jsr:@std/testing@^1.0.17"
   },
   "lock": false
 }

--- a/docs/index.html
+++ b/docs/index.html
@@ -26,6 +26,8 @@
       };
     </script>
     <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
-    <script src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-typescript.min.js"></script>
+    <script
+      src="//cdn.jsdelivr.net/npm/prismjs@1/components/prism-typescript.min.js"
+    ></script>
   </body>
 </html>

--- a/query/transaction.ts
+++ b/query/transaction.ts
@@ -279,10 +279,9 @@ export class Transaction {
         await this.#client.queryArray(
           `BEGIN ${permissions} ISOLATION LEVEL ${isolation_level};${snapshot}`,
         );
+      } else if (e instanceof PostgresError) {
+        throw new TransactionError(this.name, e);
       } else {
-        if (e instanceof PostgresError) {
-          throw new TransactionError(this.name, e);
-        }
         throw e;
       }
     }
@@ -333,16 +332,9 @@ export class Transaction {
     const chain = options?.chain ?? false;
 
     if (!this.#committed) {
-      try {
-        await this.queryArray(`COMMIT ${chain ? "AND CHAIN" : ""}`);
-        if (!chain) {
-          this.#committed = true;
-        }
-      } catch (e) {
-        if (e instanceof PostgresError) {
-          throw new TransactionError(this.name, e);
-        }
-        throw e;
+      await this.queryArray(`COMMIT ${chain ? "AND CHAIN" : ""}`);
+      if (!chain) {
+        this.#committed = true;
       }
     }
 
@@ -513,7 +505,12 @@ export class Transaction {
       return (await this.#executeQuery(query)) as QueryArrayResult<T>;
     } catch (e) {
       if (e instanceof PostgresError) {
-        await this.commit();
+        await this.rollback();
+        throw new TransactionError(this.name, e);
+      } else if (e instanceof Deno.errors.BrokenPipe) {
+        // Transaction was already rolled back by PostgreSQL on disconnect
+        this.#resetTransaction();
+        this.#updateClientLock(null);
         throw new TransactionError(this.name, e);
       }
       throw e;
@@ -615,7 +612,12 @@ export class Transaction {
       return (await this.#executeQuery(query)) as QueryObjectResult<T>;
     } catch (e) {
       if (e instanceof PostgresError) {
-        await this.commit();
+        await this.rollback();
+        throw new TransactionError(this.name, e);
+      } else if (e instanceof Deno.errors.BrokenPipe) {
+        // Transaction was already rolled back by PostgreSQL on disconnect
+        this.#resetTransaction();
+        this.#updateClientLock(null);
         throw new TransactionError(this.name, e);
       }
       throw e;
@@ -755,15 +757,7 @@ export class Transaction {
 
     // If no savepoint is provided, rollback the whole transaction and check for the chain operator
     // in order to decide whether to restart the transaction or end it
-    try {
-      await this.queryArray(`ROLLBACK ${chain_option ? "AND CHAIN" : ""}`);
-    } catch (e) {
-      if (e instanceof PostgresError) {
-        await this.commit();
-        throw new TransactionError(this.name, e);
-      }
-      throw e;
-    }
+    await this.queryArray(`ROLLBACK ${chain_option ? "AND CHAIN" : ""}`);
 
     this.#resetTransaction();
     if (!chain_option) {
@@ -857,8 +851,7 @@ export class Transaction {
       try {
         await savepoint.update();
       } catch (e) {
-        if (e instanceof PostgresError) {
-          await this.commit();
+        if (e instanceof PostgresError || e instanceof Deno.errors.BrokenPipe) {
           throw new TransactionError(this.name, e);
         }
         throw e;
@@ -874,15 +867,7 @@ export class Transaction {
         },
       );
 
-      try {
-        await savepoint.update();
-      } catch (e) {
-        if (e instanceof PostgresError) {
-          await this.commit();
-          throw new TransactionError(this.name, e);
-        }
-        throw e;
-      }
+      await savepoint.update();
       this.#savepoints.push(savepoint);
     }
 

--- a/query/transaction.ts
+++ b/query/transaction.ts
@@ -152,6 +152,7 @@ export class Savepoint {
 export class Transaction {
   #client: QueryClient;
   #executeQuery: (query: Query<ResultType>) => Promise<QueryResult>;
+  #reconnectClient: () => Promise<void>;
   /** The isolation level of the transaction */
   #isolation_level: IsolationLevel;
   #read_only: boolean;
@@ -168,13 +169,15 @@ export class Transaction {
     options: TransactionOptions | undefined,
     client: QueryClient,
     execute_query_callback: (query: Query<ResultType>) => Promise<QueryResult>,
+    reconnect_client_callback: () => Promise<void>,
     update_client_lock_callback: (name: string | null) => void,
   ) {
     this.#client = client;
-    this.#executeQuery = execute_query_callback;
     this.#isolation_level = options?.isolation_level ?? "read_committed";
     this.#read_only = options?.read_only ?? false;
     this.#snapshot = options?.snapshot;
+    this.#executeQuery = execute_query_callback;
+    this.#reconnectClient = reconnect_client_callback;
     this.#updateClientLock = update_client_lock_callback;
   }
 
@@ -270,10 +273,18 @@ export class Transaction {
         `BEGIN ${permissions} ISOLATION LEVEL ${isolation_level};${snapshot}`,
       );
     } catch (e) {
-      if (e instanceof PostgresError) {
-        throw new TransactionError(this.name, e);
+      if (e instanceof Deno.errors.BrokenPipe) {
+        // Retry with fresh connection, if connection was dropped by server since last query
+        await this.#reconnectClient();
+        await this.#client.queryArray(
+          `BEGIN ${permissions} ISOLATION LEVEL ${isolation_level};${snapshot}`,
+        );
+      } else {
+        if (e instanceof PostgresError) {
+          throw new TransactionError(this.name, e);
+        }
+        throw e;
       }
-      throw e;
     }
 
     this.#updateClientLock(this.name);

--- a/tests/auth_test.ts
+++ b/tests/auth_test.ts
@@ -2,7 +2,7 @@ import {
   assertEquals,
   assertNotEquals,
   assertRejects,
-} from "jsr:@std/assert@1.0.10";
+} from "@std/assert";
 import { Client as ScramClient, Reason } from "../connection/scram.ts";
 
 Deno.test("Scram client reproduces RFC 7677 example", async () => {

--- a/tests/connection_params_test.ts
+++ b/tests/connection_params_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert@1.0.10";
+import { assertEquals, assertThrows } from "@std/assert";
 import { fromFileUrl } from "@std/path";
 import { createParams } from "../connection/connection_params.ts";
 import { ConnectionParamsError } from "../client/error.ts";

--- a/tests/connection_test.ts
+++ b/tests/connection_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertRejects } from "jsr:@std/assert@1.0.10";
+import { assertEquals, assertRejects } from "@std/assert";
 import { join as joinPath } from "@std/path";
 import {
   getClearConfiguration,

--- a/tests/data_types_test.ts
+++ b/tests/data_types_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@1.0.10";
+import { assertEquals } from "@std/assert";
 import { decodeBase64, encodeBase64 } from "@std/encoding/base64";
 import { getMainConfiguration } from "./config.ts";
 import { generateSimpleClientTest } from "./helpers.ts";

--- a/tests/decode_test.ts
+++ b/tests/decode_test.ts
@@ -17,7 +17,7 @@ import {
   decodePoint,
   decodeTid,
 } from "../query/decoders.ts";
-import { assertEquals, assertThrows } from "jsr:@std/assert@1.0.10";
+import { assertEquals, assertThrows } from "@std/assert";
 import { Oid } from "../query/oid.ts";
 
 Deno.test("decodeBigint", function () {

--- a/tests/encode_test.ts
+++ b/tests/encode_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@1.0.10";
+import { assertEquals } from "@std/assert";
 import { encodeArgument } from "../query/encode.ts";
 
 // internally `encodeArguments` uses `getTimezoneOffset` to encode Date

--- a/tests/pool_test.ts
+++ b/tests/pool_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals } from "jsr:@std/assert@1.0.10";
+import { assertEquals } from "@std/assert";
 import { getMainConfiguration } from "./config.ts";
 import { generatePoolClientTest } from "./helpers.ts";
 

--- a/tests/query_client_test.ts
+++ b/tests/query_client_test.ts
@@ -13,6 +13,7 @@ import {
   assertRejects,
   assertThrows,
 } from "jsr:@std/assert@1.0.10";
+import { MockError, stub } from "jsr:@std/testing/mock";
 import { getMainConfiguration } from "./config.ts";
 import type { PoolClient, QueryClient } from "../client.ts";
 import type { ClientOptions } from "../connection/connection_params.ts";
@@ -694,9 +695,13 @@ Deno.test(
 );
 
 // This test depends on the assumption that all clients will default to
-// one reconneciton by default
+// one reconnection by default
+//
+// It also specifically tests the case where the database system sends a
+// graceful disconnect, not the case where the database connection is just
+// closed due to the database process crashing or being killed.
 Deno.test(
-  "Default reconnection",
+  "Default reconnection after graceful database connection close",
   withClient(async (client) => {
     await assertRejects(
       () =>
@@ -709,6 +714,64 @@ Deno.test(
       fields: ["res"],
     });
     assertEquals(result[0].res, 1);
+
+    assertEquals(client.connected, true);
+  }),
+);
+
+// This test depends on the assumption that all clients will default to
+// one reconnection by default
+Deno.test(
+  "Default reconnection after connection drop",
+  withClient(async (client) => {
+    // Test that connection is OK
+    const { rows: result } = await client.queryObject<{ res: number }>({
+      text: `SELECT 1`,
+      fields: ["res"],
+    });
+    assertEquals(result[0].res, 1);
+
+    // Use mock simulate irrecoverably broken pipe
+    const connWrite = stub(
+      WritableStreamDefaultWriter.prototype,
+      "write",
+      (_buffer) => {
+        throw new Deno.errors.BrokenPipe();
+      },
+    );
+    try {
+      await assertRejects(
+        () => client.queryArray`SELECT 1`,
+        Deno.errors.BrokenPipe,
+      );
+    } finally {
+      connWrite.restore();
+    }
+
+    // Use mock simulate broken pipe, that can be healed by reconnecting
+    const connWrite2 = stub(
+      WritableStreamDefaultWriter.prototype,
+      "write",
+      (_buffer) => {
+        connWrite2.restore();
+        throw new Deno.errors.BrokenPipe();
+      },
+    );
+    try {
+      const { rows: result2 } = await client.queryObject<{ res: number }>({
+        text: `SELECT 1`,
+        fields: ["res"],
+      });
+      assertEquals(result2[0].res, 1);
+    } finally {
+      // Restoring must fail here because it already happened
+      //
+      // If this fails, it means the Mock was never invoked and the test must be updated!
+      assertThrows(
+        () => connWrite2.restore(),
+        MockError,
+      );
+    }
 
     assertEquals(client.connected, true);
   }),
@@ -1495,6 +1558,40 @@ Deno.test(
       `The transaction "${name}" has been aborted`,
     );
     assertEquals(client.session.current_transaction, null);
+  }),
+);
+
+Deno.test(
+  "Transaction fails after connection drop",
+  withClient(async (client) => {
+    const name = "transactionFailsOnConnectionDrop";
+    const transaction = client.createTransaction(name);
+
+    await transaction.begin();
+
+    // Use mock simulate broken pipe
+    const connWrite = stub(
+      WritableStreamDefaultWriter.prototype,
+      "write",
+      (_buffer) => {
+        throw new Deno.errors.BrokenPipe();
+      },
+    );
+    try {
+      await assertRejects(
+        () => transaction.queryArray`SELECT 1`,
+        TransactionError,
+      );
+    } finally {
+      connWrite.restore();
+    }
+
+    // Test that connection is OK afterward
+    const { rows: result } = await client.queryObject<{ res: number }>({
+      text: `SELECT 1`,
+      fields: ["res"],
+    });
+    assertEquals(result[0].res, 1);
   }),
 );
 

--- a/tests/query_client_test.ts
+++ b/tests/query_client_test.ts
@@ -12,8 +12,8 @@ import {
   assertObjectMatch,
   assertRejects,
   assertThrows,
-} from "jsr:@std/assert@1.0.10";
-import { MockError, stub } from "jsr:@std/testing/mock";
+} from "@std/assert";
+import { MockError, stub } from "@std/testing/mock";
 import { getMainConfiguration } from "./config.ts";
 import type { PoolClient, QueryClient } from "../client.ts";
 import type { ClientOptions } from "../connection/connection_params.ts";

--- a/tests/query_client_test.ts
+++ b/tests/query_client_test.ts
@@ -609,13 +609,13 @@ Deno.test(
   "Handles parameter status messages on array query",
   withClient(async (client) => {
     const { rows: result_1 } = await client
-      .queryArray`SET TIME ZONE 'HongKong'`;
+      .queryArray`SET TIME ZONE 'Asia/Hong_Kong'`;
 
     assertEquals(result_1, []);
 
     const { rows: result_2 } = await client.queryObject({
       fields: ["result"],
-      text: "SET TIME ZONE 'HongKong'; SELECT 1",
+      text: "SET TIME ZONE 'Asia/Hong_Kong'; SELECT 1",
     });
 
     assertEquals(result_2, [{ result: 1 }]);
@@ -630,7 +630,7 @@ Deno.test(
     await client
       .queryArray`CREATE OR REPLACE FUNCTION PG_TEMP.CHANGE_TIMEZONE(RES INTEGER) RETURNS INT AS $$
 			BEGIN
-			SET TIME ZONE 'HongKong';
+			SET TIME ZONE 'Asia/Hong_Kong';
 			END;
 			$$ LANGUAGE PLPGSQL;`;
 
@@ -646,7 +646,7 @@ Deno.test(
     await client
       .queryArray`CREATE OR REPLACE FUNCTION PG_TEMP.CHANGE_TIMEZONE(RES INTEGER) RETURNS INT AS $$
 			BEGIN
-			SET TIME ZONE 'HongKong';
+			SET TIME ZONE 'Asia/Hong_Kong';
 			RETURN RES;
 			END;
 			$$ LANGUAGE PLPGSQL;`;
@@ -667,7 +667,7 @@ Deno.test(
     await client
       .queryArray`CREATE OR REPLACE FUNCTION PG_TEMP.CHANGE_TIMEZONE() RETURNS INT AS $$
 			BEGIN
-			SET TIME ZONE 'HongKong';
+			SET TIME ZONE 'Asia/Hong_Kong';
 			END;
 			$$ LANGUAGE PLPGSQL;`;
 

--- a/tests/test_deps.ts
+++ b/tests/test_deps.ts
@@ -6,4 +6,4 @@ export {
   assertObjectMatch,
   assertRejects,
   assertThrows,
-} from "jsr:@std/assert@1.0.10";
+} from "@std/assert";

--- a/tests/utils_test.ts
+++ b/tests/utils_test.ts
@@ -1,4 +1,4 @@
-import { assertEquals, assertThrows } from "jsr:@std/assert@1.0.10";
+import { assertEquals, assertThrows } from "@std/assert";
 import { parseConnectionUri, type Uri } from "../utils/utils.ts";
 import { DeferredAccessStack, DeferredStack } from "../utils/deferred.ts";
 


### PR DESCRIPTION
Reconnects to PostgreSQL when receiving `BrokenPipe` upon executing freestandig query or transaction start.

In-transaction queries are not retried, since we’d have to replay all previous queries and still risk inconsistency if a subsequently issued queries depended on data previously read during the aborted transaction. (We’d *also* have to keep a log of all previously returned data to verify that it hasn’t changed when reissuing the command!)
This patchset *does* convert `BrokenPipe` to `TransactionError` to let applications know that they should restart the transaction: If the database is really down, the subsequent `.begin()` will then fail with a `ConnectionError`.

This allow removes the calls to `.commit()` in the transaction error handling, see last commit message for why and why this doesn’t actually change application observable behaviour.

Fixes #436